### PR TITLE
Functions Inference

### DIFF
--- a/frontend/constraint/compat.py
+++ b/frontend/constraint/compat.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import sys
+
+PY2 = sys.version_info[0] == 2
+PY3 = (sys.version_info[0] >= 3)
+
+if PY3:
+    string_types = str
+    xrange = range
+else:
+    string_types = basestring  # noqa
+    xrange = xrange

--- a/frontend/constraint/constraint.py
+++ b/frontend/constraint/constraint.py
@@ -1,0 +1,1419 @@
+#!/usr/bin/python
+#
+# Copyright (c) 2005-2014 - Gustavo Niemeyer <gustavo@niemeyer.net>
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
+@var Unassigned: Helper object instance representing unassigned values
+
+@sort: Problem, Variable, Domain
+@group Solvers: Solver,
+                BacktrackingSolver,
+                RecursiveBacktrackingSolver,
+                MinConflictsSolver
+@group Constraints: Constraint,
+                    FunctionConstraint,
+                    AllDifferentConstraint,
+                    AllEqualConstraint,
+                    MaxSumConstraint,
+                    ExactSumConstraint,
+                    MinSumConstraint,
+                    InSetConstraint,
+                    NotInSetConstraint,
+                    SomeInSetConstraint,
+                    SomeNotInSetConstraint
+"""
+
+from __future__ import absolute_import, division, print_function
+from frontend.i_types import Generic as Domain
+
+from .version import (__author__, __copyright__, __credits__, __license__,  # noqa
+                      __version__, __email__, __status__, __url__)  # noqa
+
+import random
+import copy
+from .compat import xrange
+
+__all__ = ["Problem", "Variable", "Unassigned",
+           "Solver", "BacktrackingSolver", "RecursiveBacktrackingSolver",
+           "MinConflictsSolver", "Constraint", "FunctionConstraint",
+           "AllDifferentConstraint", "AllEqualConstraint", "MaxSumConstraint",
+           "ExactSumConstraint", "MinSumConstraint", "InSetConstraint",
+           "NotInSetConstraint", "SomeInSetConstraint",
+           "SomeNotInSetConstraint"]
+
+
+class Problem(object):
+    """
+    Class used to define a problem and retrieve solutions
+    """
+
+    def __init__(self, solver=None):
+        """
+        @param solver: Problem solver used to find solutions
+                       (default is L{BacktrackingSolver})
+        @type solver:  instance of a L{Solver} subclass
+        """
+        self._solver = solver or BacktrackingSolver()
+        self._constraints = []
+        self._variables = {}
+
+    def reset(self):
+        """
+        Reset the current problem definition
+
+        Example:
+
+        >>> problem = Problem()
+        >>> problem.addVariable("a", [1, 2])
+        >>> problem.reset()
+        >>> problem.getSolution()
+        >>>
+        """
+        del self._constraints[:]
+        self._variables.clear()
+
+    def setSolver(self, solver):
+        """
+        Change the problem solver currently in use
+
+        Example:
+
+        >>> solver = BacktrackingSolver()
+        >>> problem = Problem(solver)
+        >>> problem.getSolver() is solver
+        True
+
+        @param solver: New problem solver
+        @type  solver: instance of a C{Solver} subclass
+        """
+        self._solver = solver
+
+    def getSolver(self):
+        """
+        Obtain the problem solver currently in use
+
+        Example:
+
+        >>> solver = BacktrackingSolver()
+        >>> problem = Problem(solver)
+        >>> problem.getSolver() is solver
+        True
+
+        @return: Solver currently in use
+        @rtype: instance of a L{Solver} subclass
+        """
+        return self._solver
+
+    def addVariable(self, variable, domain):
+        """
+        Add a variable to the problem
+
+        Example:
+
+        >>> problem = Problem()
+        >>> problem.addVariable("a", [1, 2])
+        >>> problem.getSolution() in ({'a': 1}, {'a': 2})
+        True
+
+        @param variable: Object representing a problem variable
+        @type  variable: hashable object
+        @param domain: Set of items defining the possible values that
+                       the given variable may assume
+        @type  domain: list, tuple, or instance of C{Domain}
+        """
+        if variable in self._variables:
+            msg = "Tried to insert duplicated variable %s" % repr(variable)
+            raise ValueError(msg)
+        if hasattr(domain, '__getitem__'):
+            domain = Domain(domain)
+        elif isinstance(domain, Domain):
+            domain = copy.copy(domain)
+        else:
+            msg = "Domains must be instances of subclasses of the Domain class"
+            raise TypeError(msg)
+        if not domain:
+            raise ValueError("Domain is empty")
+        self._variables[variable] = domain
+
+    def getDomain(self, variable):
+        if variable not in self._variables:
+            raise ValueError("Variable {} doesn't exist".format(variable))
+        return self._variables[variable]
+
+    def setDomain(self, variable, domain):
+        if variable not in self._variables:
+            raise ValueError("Variable {} doesn't exist".format(variable))
+        if hasattr(domain, '__getitem__'):
+            domain = Domain(domain)
+        elif isinstance(domain, Domain):
+            domain = copy.copy(domain)
+        else:
+            msg = "Domains must be instances of subclasses of the Domain class"
+            raise TypeError(msg)
+        if not domain:
+            raise ValueError("Domain is empty")
+        self._variables[variable] = domain
+
+    def addVariables(self, variables, domain):
+        """
+        Add one or more variables to the problem
+
+        Example:
+
+        >>> problem = Problem()
+        >>> problem.addVariables(["a", "b"], [1, 2, 3])
+        >>> solutions = problem.getSolutions()
+        >>> len(solutions)
+        9
+        >>> {'a': 3, 'b': 1} in solutions
+        True
+
+        @param variables: Any object containing a sequence of objects
+                          represeting problem variables
+        @type  variables: sequence of hashable objects
+        @param domain: Set of items defining the possible values that
+                       the given variables may assume
+        @type  domain: list, tuple, or instance of C{Domain}
+        """
+        for variable in variables:
+            self.addVariable(variable, domain)
+
+    def addConstraint(self, constraint, variables=None):
+        """
+        Add a constraint to the problem
+
+        Example:
+
+        >>> problem = Problem()
+        >>> problem.addVariables(["a", "b"], [1, 2, 3])
+        >>> problem.addConstraint(lambda a, b: b == a+1, ["a", "b"])
+        >>> solutions = problem.getSolutions()
+        >>>
+
+        @param constraint: Constraint to be included in the problem
+        @type  constraint: instance a L{Constraint} subclass or a
+                           function to be wrapped by L{FunctionConstraint}
+        @param variables: Variables affected by the constraint (default to
+                          all variables). Depending on the constraint type
+                          the order may be important.
+        @type  variables: set or sequence of variables
+        """
+        if not isinstance(constraint, Constraint):
+            if callable(constraint):
+                constraint = FunctionConstraint(constraint)
+            else:
+                msg = "Constraints must be instances of subclasses "\
+                      "of the Constraint class"
+                raise ValueError(msg)
+        self._constraints.append((constraint, variables))
+
+    def getSolution(self):
+        """
+        Find and return a solution to the problem
+
+        Example:
+
+        >>> problem = Problem()
+        >>> problem.getSolution() is None
+        True
+        >>> problem.addVariables(["a"], [42])
+        >>> problem.getSolution()
+        {'a': 42}
+
+        @return: Solution for the problem
+        @rtype: dictionary mapping variables to values
+        """
+        domains, constraints, vconstraints = self._getArgs()
+        if not domains:
+            return None
+        return self._solver.getSolution(domains, constraints, vconstraints)
+
+    def getSolutions(self):
+        """
+        Find and return all solutions to the problem
+
+        Example:
+
+        >>> problem = Problem()
+        >>> problem.getSolutions() == []
+        True
+        >>> problem.addVariables(["a"], [42])
+        >>> problem.getSolutions()
+        [{'a': 42}]
+
+        @return: All solutions for the problem
+        @rtype: list of dictionaries mapping variables to values
+        """
+        domains, constraints, vconstraints = self._getArgs()
+        if not domains:
+            return []
+        return self._solver.getSolutions(domains, constraints, vconstraints)
+
+    def getSolutionIter(self):
+        """
+        Return an iterator to the solutions of the problem
+
+        Example:
+
+        >>> problem = Problem()
+        >>> list(problem.getSolutionIter()) == []
+        True
+        >>> problem.addVariables(["a"], [42])
+        >>> iter = problem.getSolutionIter()
+        >>> next(iter)
+        {'a': 42}
+        >>> next(iter)
+        Traceback (most recent call last):
+          File "<stdin>", line 1, in ?
+        StopIteration
+        """
+        domains, constraints, vconstraints = self._getArgs()
+        if not domains:
+            return iter(())
+        return self._solver.getSolutionIter(domains, constraints,
+                                            vconstraints)
+
+    def _getArgs(self):
+        domains = self._variables.copy()
+        allvariables = domains.keys()
+        constraints = []
+        for constraint, variables in self._constraints:
+            if not variables:
+                variables = allvariables
+            constraints.append((constraint, variables))
+        vconstraints = {}
+        for variable in domains:
+            vconstraints[variable] = []
+        for constraint, variables in constraints:
+            for variable in variables:
+                vconstraints[variable].append((constraint, variables))
+        for constraint, variables in constraints[:]:
+            constraint.preProcess(variables, domains,
+                                  constraints, vconstraints)
+        for domain in domains.values():
+            domain.resetState()
+            if not domain:
+                return None, None, None
+        # doArc8(getArcs(domains, constraints), domains, {})
+        return domains, constraints, vconstraints
+
+# ----------------------------------------------------------------------
+# Solvers
+# ----------------------------------------------------------------------
+
+
+def getArcs(domains, constraints):
+    """
+    Return a dictionary mapping pairs (arcs) of constrained variables
+
+    @attention: Currently unused.
+    """
+    arcs = {}
+    for x in constraints:
+        constraint, variables = x
+        if len(variables) == 2:
+            variable1, variable2 = variables
+            arcs.setdefault(variable1, {})\
+                .setdefault(variable2, [])\
+                .append(x)
+            arcs.setdefault(variable2, {})\
+                .setdefault(variable1, [])\
+                .append(x)
+    return arcs
+
+
+def doArc8(arcs, domains, assignments):
+    """
+    Perform the ARC-8 arc checking algorithm and prune domains
+
+    @attention: Currently unused.
+    """
+    check = dict.fromkeys(domains, True)
+    while check:
+        variable, _ = check.popitem()
+        if variable not in arcs or variable in assignments:
+            continue
+        domain = domains[variable]
+        arcsvariable = arcs[variable]
+        for othervariable in arcsvariable:
+            arcconstraints = arcsvariable[othervariable]
+            if othervariable in assignments:
+                otherdomain = [assignments[othervariable]]
+            else:
+                otherdomain = domains[othervariable]
+            if domain:
+                # changed = False
+                for value in domain[:]:
+                    assignments[variable] = value
+                    if otherdomain:
+                        for othervalue in otherdomain:
+                            assignments[othervariable] = othervalue
+                            for constraint, variables in arcconstraints:
+                                if not constraint(variables, domains,
+                                                  assignments, True):
+                                    break
+                            else:
+                                # All constraints passed. Value is safe.
+                                break
+                        else:
+                            # All othervalues failed. Kill value.
+                            domain.hideValue(value)
+                            # changed = True
+                        del assignments[othervariable]
+                del assignments[variable]
+                # if changed:
+                #     check.update(dict.fromkeys(arcsvariable))
+            if not domain:
+                return False
+    return True
+
+
+class Solver(object):
+    """
+    Abstract base class for solvers
+
+    @sort: getSolution, getSolutions, getSolutionIter
+    """
+
+    def getSolution(self, domains, constraints, vconstraints):
+        """
+        Return one solution for the given problem
+
+        @param domains: Dictionary mapping variables to their domains
+        @type  domains: dict
+        @param constraints: List of pairs of (constraint, variables)
+        @type  constraints: list
+        @param vconstraints: Dictionary mapping variables to a list of
+                             constraints affecting the given variables.
+        @type  vconstraints: dict
+        """
+        msg = "%s is an abstract class" % self.__class__.__name__
+        raise NotImplementedError(msg)
+
+    def getSolutions(self, domains, constraints, vconstraints):
+        """
+        Return all solutions for the given problem
+
+        @param domains: Dictionary mapping variables to domains
+        @type  domains: dict
+        @param constraints: List of pairs of (constraint, variables)
+        @type  constraints: list
+        @param vconstraints: Dictionary mapping variables to a list of
+                             constraints affecting the given variables.
+        @type  vconstraints: dict
+        """
+        msg = "%s provides only a single solution" % self.__class__.__name__
+        raise NotImplementedError(msg)
+
+    def getSolutionIter(self, domains, constraints, vconstraints):
+        """
+        Return an iterator for the solutions of the given problem
+
+        @param domains: Dictionary mapping variables to domains
+        @type  domains: dict
+        @param constraints: List of pairs of (constraint, variables)
+        @type  constraints: list
+        @param vconstraints: Dictionary mapping variables to a list of
+                             constraints affecting the given variables.
+        @type  vconstraints: dict
+        """
+        msg = "%s doesn't provide iteration" % self.__class__.__name__
+        raise NotImplementedError(msg)
+
+
+class BacktrackingSolver(Solver):
+    """
+    Problem solver with backtracking capabilities
+
+    Examples:
+
+    >>> result = [[('a', 1), ('b', 2)],
+    ...           [('a', 1), ('b', 3)],
+    ...           [('a', 2), ('b', 3)]]
+
+    >>> problem = Problem(BacktrackingSolver())
+    >>> problem.addVariables(["a", "b"], [1, 2, 3])
+    >>> problem.addConstraint(lambda a, b: b > a, ["a", "b"])
+
+    >>> solution = problem.getSolution()
+    >>> sorted(solution.items()) in result
+    True
+
+    >>> for solution in problem.getSolutionIter():
+    ...     sorted(solution.items()) in result
+    True
+    True
+    True
+
+    >>> for solution in problem.getSolutions():
+    ...     sorted(solution.items()) in result
+    True
+    True
+    True
+    """
+
+    def __init__(self, forwardcheck=True):
+        """
+        @param forwardcheck: If false forward checking will not be requested
+                             to constraints while looking for solutions
+                             (default is true)
+        @type  forwardcheck: bool
+        """
+        self._forwardcheck = forwardcheck
+
+    def getSolutionIter(self, domains, constraints, vconstraints):
+        forwardcheck = self._forwardcheck
+        assignments = {}
+
+        queue = []
+
+        while True:
+
+            # Mix the Degree and Minimum Remaing Values (MRV) heuristics
+            lst = [(-len(vconstraints[variable]),
+                    len(domains[variable]), variable) for variable in domains]
+            lst.sort()
+            for item in lst:
+                if item[-1] not in assignments:
+                    # Found unassigned variable
+                    variable = item[-1]
+                    values = domains[variable][:]
+                    if forwardcheck:
+                        pushdomains = [domains[x] for x in domains
+                                       if x not in assignments and x != variable]
+                    else:
+                        pushdomains = None
+                    break
+            else:
+                # No unassigned variables. We've got a solution. Go back
+                # to last variable, if there's one.
+                yield assignments.copy()
+                if not queue:
+                    return
+                variable, values, pushdomains = queue.pop()
+                if pushdomains:
+                    for domain in pushdomains:
+                        domain.popState()
+
+            while True:
+                # We have a variable. Do we have any values left?
+                if not values:
+                    # No. Go back to last variable, if there's one.
+                    del assignments[variable]
+                    while queue:
+                        variable, values, pushdomains = queue.pop()
+                        if pushdomains:
+                            for domain in pushdomains:
+                                domain.popState()
+                        if values:
+                            break
+                        del assignments[variable]
+                    else:
+                        return
+
+                # Got a value. Check it.
+                assignments[variable] = values.pop()
+
+                if pushdomains:
+                    for domain in pushdomains:
+                        domain.pushState()
+
+                for constraint, variables in vconstraints[variable]:
+                    if not constraint(variables, domains, assignments,
+                                      pushdomains):
+                        # Value is not good.
+                        break
+                else:
+                    break
+
+                if pushdomains:
+                    for domain in pushdomains:
+                        domain.popState()
+
+            # Push state before looking for next variable.
+            queue.append((variable, values, pushdomains))
+
+        raise RuntimeError("Can't happen")
+
+    def getSolution(self, domains, constraints, vconstraints):
+        iter = self.getSolutionIter(domains, constraints, vconstraints)
+        try:
+            return next(iter)
+        except StopIteration:
+            return None
+
+    def getSolutions(self, domains, constraints, vconstraints):
+        return list(self.getSolutionIter(domains, constraints, vconstraints))
+
+
+class RecursiveBacktrackingSolver(Solver):
+    """
+    Recursive problem solver with backtracking capabilities
+
+    Examples:
+
+    >>> result = [[('a', 1), ('b', 2)],
+    ...           [('a', 1), ('b', 3)],
+    ...           [('a', 2), ('b', 3)]]
+
+    >>> problem = Problem(RecursiveBacktrackingSolver())
+    >>> problem.addVariables(["a", "b"], [1, 2, 3])
+    >>> problem.addConstraint(lambda a, b: b > a, ["a", "b"])
+
+    >>> solution = problem.getSolution()
+    >>> sorted(solution.items()) in result
+    True
+
+    >>> for solution in problem.getSolutions():
+    ...     sorted(solution.items()) in result
+    True
+    True
+    True
+
+    >>> problem.getSolutionIter()
+    Traceback (most recent call last):
+       ...
+    NotImplementedError: RecursiveBacktrackingSolver doesn't provide iteration
+    """
+
+    def __init__(self, forwardcheck=True):
+        """
+        @param forwardcheck: If false forward checking will not be requested
+                             to constraints while looking for solutions
+                             (default is true)
+        @type  forwardcheck: bool
+        """
+        self._forwardcheck = forwardcheck
+
+    def recursiveBacktracking(self, solutions, domains, vconstraints,
+                              assignments, single):
+
+        # Mix the Degree and Minimum Remaing Values (MRV) heuristics
+        lst = [(-len(vconstraints[variable]),
+                len(domains[variable]), variable) for variable in domains]
+        lst.sort()
+        for item in lst:
+            if item[-1] not in assignments:
+                # Found an unassigned variable. Let's go.
+                break
+        else:
+            # No unassigned variables. We've got a solution.
+            solutions.append(assignments.copy())
+            return solutions
+
+        variable = item[-1]
+        assignments[variable] = None
+
+        forwardcheck = self._forwardcheck
+        if forwardcheck:
+            pushdomains = [domains[x] for x in domains if x not in assignments]
+        else:
+            pushdomains = None
+
+        for value in domains[variable]:
+            assignments[variable] = value
+            if pushdomains:
+                for domain in pushdomains:
+                    domain.pushState()
+            for constraint, variables in vconstraints[variable]:
+                if not constraint(variables, domains, assignments,
+                                  pushdomains):
+                    # Value is not good.
+                    break
+            else:
+                # Value is good. Recurse and get next variable.
+                self.recursiveBacktracking(solutions, domains, vconstraints,
+                                           assignments, single)
+                if solutions and single:
+                    return solutions
+            if pushdomains:
+                for domain in pushdomains:
+                    domain.popState()
+        del assignments[variable]
+        return solutions
+
+    def getSolution(self, domains, constraints, vconstraints):
+        solutions = self.recursiveBacktracking([], domains, vconstraints,
+                                               {}, True)
+        return solutions and solutions[0] or None
+
+    def getSolutions(self, domains, constraints, vconstraints):
+        return self.recursiveBacktracking([], domains, vconstraints,
+                                          {}, False)
+
+
+class MinConflictsSolver(Solver):
+    """
+    Problem solver based on the minimum conflicts theory
+
+    Examples:
+
+    >>> result = [[('a', 1), ('b', 2)],
+    ...           [('a', 1), ('b', 3)],
+    ...           [('a', 2), ('b', 3)]]
+
+    >>> problem = Problem(MinConflictsSolver())
+    >>> problem.addVariables(["a", "b"], [1, 2, 3])
+    >>> problem.addConstraint(lambda a, b: b > a, ["a", "b"])
+
+    >>> solution = problem.getSolution()
+    >>> sorted(solution.items()) in result
+    True
+
+    >>> problem.getSolutions()
+    Traceback (most recent call last):
+       ...
+    NotImplementedError: MinConflictsSolver provides only a single solution
+
+    >>> problem.getSolutionIter()
+    Traceback (most recent call last):
+       ...
+    NotImplementedError: MinConflictsSolver doesn't provide iteration
+    """
+
+    def __init__(self, steps=1000):
+        """
+        @param steps: Maximum number of steps to perform before giving up
+                      when looking for a solution (default is 1000)
+        @type  steps: int
+        """
+        self._steps = steps
+
+    def getSolution(self, domains, constraints, vconstraints):
+        assignments = {}
+        # Initial assignment
+        for variable in domains:
+            assignments[variable] = random.choice(domains[variable])
+        for _ in xrange(self._steps):
+            conflicted = False
+            lst = domains.keys()
+            random.shuffle(lst)
+            for variable in lst:
+                # Check if variable is not in conflict
+                for constraint, variables in vconstraints[variable]:
+                    if not constraint(variables, domains, assignments):
+                        break
+                else:
+                    continue
+                # Variable has conflicts. Find values with less conflicts.
+                mincount = len(vconstraints[variable])
+                minvalues = []
+                for value in domains[variable]:
+                    assignments[variable] = value
+                    count = 0
+                    for constraint, variables in vconstraints[variable]:
+                        if not constraint(variables, domains, assignments):
+                            count += 1
+                    if count == mincount:
+                        minvalues.append(value)
+                    elif count < mincount:
+                        mincount = count
+                        del minvalues[:]
+                        minvalues.append(value)
+                # Pick a random one from these values.
+                assignments[variable] = random.choice(minvalues)
+                conflicted = True
+            if not conflicted:
+                return assignments
+        return None
+
+# ----------------------------------------------------------------------
+# Variables
+# ----------------------------------------------------------------------
+
+
+class Variable(object):
+    """
+    helper class for variable definition
+
+    using this class is optional, since any hashable object,
+    including plain strings and integers, may be used as variables.
+    """
+
+    def __init__(self, name):
+        """
+        @param name: generic variable name for problem-specific purposes
+        @type  name: string
+        """
+        self.name = name
+
+    def __repr__(self):
+        return self.name
+
+    def get_name(self):
+        return self.name
+
+
+Unassigned = Variable("Unassigned")
+
+# ----------------------------------------------------------------------
+# Constraints
+# ----------------------------------------------------------------------
+
+
+class Constraint(object):
+    """
+    Abstract base class for constraints
+    """
+
+    def __call__(self, variables, domains, assignments, forwardcheck=False):
+        """
+        Perform the constraint checking
+
+        If the forwardcheck parameter is not false, besides telling if
+        the constraint is currently broken or not, the constraint
+        implementation may choose to hide values from the domains of
+        unassigned variables to prevent them from being used, and thus
+        prune the search space.
+
+        @param variables: Variables affected by that constraint, in the
+                          same order provided by the user
+        @type  variables: sequence
+        @param domains: Dictionary mapping variables to their domains
+        @type  domains: dict
+        @param assignments: Dictionary mapping assigned variables to their
+                            current assumed value
+        @type  assignments: dict
+        @param forwardcheck: Boolean value stating whether forward checking
+                             should be performed or not
+        @return: Boolean value stating if this constraint is currently
+                 broken or not
+        @rtype: bool
+        """
+        return True
+
+    def preProcess(self, variables, domains, constraints, vconstraints):
+        """
+        Preprocess variable domains
+
+        This method is called before starting to look for solutions,
+        and is used to prune domains with specific constraint logic
+        when possible. For instance, any constraints with a single
+        variable may be applied on all possible values and removed,
+        since they may act on individual values even without further
+        knowledge about other assignments.
+
+        @param variables: Variables affected by that constraint, in the
+                          same order provided by the user
+        @type  variables: sequence
+        @param domains: Dictionary mapping variables to their domains
+        @type  domains: dict
+        @param constraints: List of pairs of (constraint, variables)
+        @type  constraints: list
+        @param vconstraints: Dictionary mapping variables to a list of
+                             constraints affecting the given variables.
+        @type  vconstraints: dict
+        """
+        if len(variables) == 1:
+            variable = variables[0]
+            domain = domains[variable]
+            for value in domain[:]:
+                if not self(variables, domains, {variable: value}):
+                    domain.remove(value)
+            constraints.remove((self, variables))
+            vconstraints[variable].remove((self, variables))
+
+    def forwardCheck(self, variables, domains, assignments,
+                     _unassigned=Unassigned):
+        """
+        Helper method for generic forward checking
+
+        Currently, this method acts only when there's a single
+        unassigned variable.
+
+        @param variables: Variables affected by that constraint, in the
+                          same order provided by the user
+        @type  variables: sequence
+        @param domains: Dictionary mapping variables to their domains
+        @type  domains: dict
+        @param assignments: Dictionary mapping assigned variables to their
+                            current assumed value
+        @type  assignments: dict
+        @return: Boolean value stating if this constraint is currently
+                 broken or not
+        @rtype: bool
+        """
+        unassignedvariable = _unassigned
+        for variable in variables:
+            if variable not in assignments:
+                if unassignedvariable is _unassigned:
+                    unassignedvariable = variable
+                else:
+                    break
+        else:
+            if unassignedvariable is not _unassigned:
+                # Remove from the unassigned variable domain's all
+                # values which break our variable's constraints.
+                domain = domains[unassignedvariable]
+                if domain:
+                    for value in domain[:]:
+                        assignments[unassignedvariable] = value
+                        if not self(variables, domains, assignments):
+                            domain.hideValue(value)
+                    del assignments[unassignedvariable]
+                if not domain:
+                    return False
+        return True
+
+
+class FunctionConstraint(Constraint):
+    """
+    Constraint which wraps a function defining the constraint logic
+
+    Examples:
+
+    >>> problem = Problem()
+    >>> problem.addVariables(["a", "b"], [1, 2])
+    >>> def func(a, b):
+    ...     return b > a
+    >>> problem.addConstraint(func, ["a", "b"])
+    >>> problem.getSolution()
+    {'a': 1, 'b': 2}
+
+    >>> problem = Problem()
+    >>> problem.addVariables(["a", "b"], [1, 2])
+    >>> def func(a, b):
+    ...     return b > a
+    >>> problem.addConstraint(FunctionConstraint(func), ["a", "b"])
+    >>> problem.getSolution()
+    {'a': 1, 'b': 2}
+    """
+
+    def __init__(self, func, assigned=True):
+        """
+        @param func: Function wrapped and queried for constraint logic
+        @type  func: callable object
+        @param assigned: Whether the function may receive unassigned
+                         variables or not
+        @type  assigned: bool
+        """
+        self._func = func
+        self._assigned = assigned
+
+    def __call__(self, variables, domains, assignments, forwardcheck=False,
+                 _unassigned=Unassigned):
+        parms = [assignments.get(x, _unassigned) for x in variables]
+        missing = parms.count(_unassigned)
+        if missing:
+            return ((self._assigned or self._func(*parms)) and
+                    (not forwardcheck or missing != 1 or
+                     self.forwardCheck(variables, domains, assignments)))
+        return self._func(*parms)
+
+
+class AllDifferentConstraint(Constraint):
+    """
+    Constraint enforcing that values of all given variables are different
+
+    Example:
+
+    >>> problem = Problem()
+    >>> problem.addVariables(["a", "b"], [1, 2])
+    >>> problem.addConstraint(AllDifferentConstraint())
+    >>> sorted(sorted(x.items()) for x in problem.getSolutions())
+    [[('a', 1), ('b', 2)], [('a', 2), ('b', 1)]]
+    """
+
+    def __call__(self, variables, domains, assignments, forwardcheck=False,
+                 _unassigned=Unassigned):
+        seen = {}
+        for variable in variables:
+            value = assignments.get(variable, _unassigned)
+            if value is not _unassigned:
+                if value in seen:
+                    return False
+                seen[value] = True
+        if forwardcheck:
+            for variable in variables:
+                if variable not in assignments:
+                    domain = domains[variable]
+                    for value in seen:
+                        if value in domain:
+                            domain.hideValue(value)
+                            if not domain:
+                                return False
+        return True
+
+
+class AllEqualConstraint(Constraint):
+    """
+    Constraint enforcing that values of all given variables are equal
+
+    Example:
+
+    >>> problem = Problem()
+    >>> problem.addVariables(["a", "b"], [1, 2])
+    >>> problem.addConstraint(AllEqualConstraint())
+    >>> sorted(sorted(x.items()) for x in problem.getSolutions())
+    [[('a', 1), ('b', 1)], [('a', 2), ('b', 2)]]
+    """
+
+    def __call__(self, variables, domains, assignments, forwardcheck=False,
+                 _unassigned=Unassigned):
+        singlevalue = _unassigned
+        for variable in variables:
+            value = assignments.get(variable, _unassigned)
+            if singlevalue is _unassigned:
+                singlevalue = value
+            elif value is not _unassigned and value != singlevalue:
+                return False
+        if forwardcheck and singlevalue is not _unassigned:
+            for variable in variables:
+                if variable not in assignments:
+                    domain = domains[variable]
+                    if singlevalue not in domain:
+                        return False
+                    for value in domain[:]:
+                        if value != singlevalue:
+                            domain.hideValue(value)
+        return True
+
+
+class MaxSumConstraint(Constraint):
+    """
+    Constraint enforcing that values of given variables sum up to
+    a given amount
+
+    Example:
+
+    >>> problem = Problem()
+    >>> problem.addVariables(["a", "b"], [1, 2])
+    >>> problem.addConstraint(MaxSumConstraint(3))
+    >>> sorted(sorted(x.items()) for x in problem.getSolutions())
+    [[('a', 1), ('b', 1)], [('a', 1), ('b', 2)], [('a', 2), ('b', 1)]]
+    """
+
+    def __init__(self, maxsum, multipliers=None):
+        """
+        @param maxsum: Value to be considered as the maximum sum
+        @type  maxsum: number
+        @param multipliers: If given, variable values will be multiplied by
+                            the given factors before being summed to be checked
+        @type  multipliers: sequence of numbers
+        """
+        self._maxsum = maxsum
+        self._multipliers = multipliers
+
+    def preProcess(self, variables, domains, constraints, vconstraints):
+        Constraint.preProcess(self, variables, domains,
+                              constraints, vconstraints)
+        multipliers = self._multipliers
+        maxsum = self._maxsum
+        if multipliers:
+            for variable, multiplier in zip(variables, multipliers):
+                domain = domains[variable]
+                for value in domain[:]:
+                    if value * multiplier > maxsum:
+                        domain.remove(value)
+        else:
+            for variable in variables:
+                domain = domains[variable]
+                for value in domain[:]:
+                    if value > maxsum:
+                        domain.remove(value)
+
+    def __call__(self, variables, domains, assignments, forwardcheck=False):
+        multipliers = self._multipliers
+        maxsum = self._maxsum
+        sum = 0
+        if multipliers:
+            for variable, multiplier in zip(variables, multipliers):
+                if variable in assignments:
+                    sum += assignments[variable] * multiplier
+            if type(sum) is float:
+                sum = round(sum, 10)
+            if sum > maxsum:
+                return False
+            if forwardcheck:
+                for variable, multiplier in zip(variables, multipliers):
+                    if variable not in assignments:
+                        domain = domains[variable]
+                        for value in domain[:]:
+                            if sum + value * multiplier > maxsum:
+                                domain.hideValue(value)
+                        if not domain:
+                            return False
+        else:
+            for variable in variables:
+                if variable in assignments:
+                    sum += assignments[variable]
+            if type(sum) is float:
+                sum = round(sum, 10)
+            if sum > maxsum:
+                return False
+            if forwardcheck:
+                for variable in variables:
+                    if variable not in assignments:
+                        domain = domains[variable]
+                        for value in domain[:]:
+                            if sum + value > maxsum:
+                                domain.hideValue(value)
+                        if not domain:
+                            return False
+        return True
+
+
+class ExactSumConstraint(Constraint):
+    """
+    Constraint enforcing that values of given variables sum exactly
+    to a given amount
+
+    Example:
+
+    >>> problem = Problem()
+    >>> problem.addVariables(["a", "b"], [1, 2])
+    >>> problem.addConstraint(ExactSumConstraint(3))
+    >>> sorted(sorted(x.items()) for x in problem.getSolutions())
+    [[('a', 1), ('b', 2)], [('a', 2), ('b', 1)]]
+    """
+
+    def __init__(self, exactsum, multipliers=None):
+        """
+        @param exactsum: Value to be considered as the exact sum
+        @type  exactsum: number
+        @param multipliers: If given, variable values will be multiplied by
+                            the given factors before being summed to be checked
+        @type  multipliers: sequence of numbers
+        """
+        self._exactsum = exactsum
+        self._multipliers = multipliers
+
+    def preProcess(self, variables, domains, constraints, vconstraints):
+        Constraint.preProcess(self, variables, domains,
+                              constraints, vconstraints)
+        multipliers = self._multipliers
+        exactsum = self._exactsum
+        if multipliers:
+            for variable, multiplier in zip(variables, multipliers):
+                domain = domains[variable]
+                for value in domain[:]:
+                    if value * multiplier > exactsum:
+                        domain.remove(value)
+        else:
+            for variable in variables:
+                domain = domains[variable]
+                for value in domain[:]:
+                    if value > exactsum:
+                        domain.remove(value)
+
+    def __call__(self, variables, domains, assignments, forwardcheck=False):
+        multipliers = self._multipliers
+        exactsum = self._exactsum
+        sum = 0
+        missing = False
+        if multipliers:
+            for variable, multiplier in zip(variables, multipliers):
+                if variable in assignments:
+                    sum += assignments[variable] * multiplier
+                else:
+                    missing = True
+            if type(sum) is float:
+                sum = round(sum, 10)
+            if sum > exactsum:
+                return False
+            if forwardcheck and missing:
+                for variable, multiplier in zip(variables, multipliers):
+                    if variable not in assignments:
+                        domain = domains[variable]
+                        for value in domain[:]:
+                            if sum + value * multiplier > exactsum:
+                                domain.hideValue(value)
+                        if not domain:
+                            return False
+        else:
+            for variable in variables:
+                if variable in assignments:
+                    sum += assignments[variable]
+                else:
+                    missing = True
+            if type(sum) is float:
+                sum = round(sum, 10)
+            if sum > exactsum:
+                return False
+            if forwardcheck and missing:
+                for variable in variables:
+                    if variable not in assignments:
+                        domain = domains[variable]
+                        for value in domain[:]:
+                            if sum + value > exactsum:
+                                domain.hideValue(value)
+                        if not domain:
+                            return False
+        if missing:
+            return sum <= exactsum
+        else:
+            return sum == exactsum
+
+
+class MinSumConstraint(Constraint):
+    """
+    Constraint enforcing that values of given variables sum at least
+    to a given amount
+
+    Example:
+
+    >>> problem = Problem()
+    >>> problem.addVariables(["a", "b"], [1, 2])
+    >>> problem.addConstraint(MinSumConstraint(3))
+    >>> sorted(sorted(x.items()) for x in problem.getSolutions())
+    [[('a', 1), ('b', 2)], [('a', 2), ('b', 1)], [('a', 2), ('b', 2)]]
+    """
+
+    def __init__(self, minsum, multipliers=None):
+        """
+        @param minsum: Value to be considered as the minimum sum
+        @type  minsum: number
+        @param multipliers: If given, variable values will be multiplied by
+                            the given factors before being summed to be checked
+        @type  multipliers: sequence of numbers
+        """
+        self._minsum = minsum
+        self._multipliers = multipliers
+
+    def __call__(self, variables, domains, assignments, forwardcheck=False):
+        for variable in variables:
+            if variable not in assignments:
+                return True
+        else:
+            multipliers = self._multipliers
+            minsum = self._minsum
+            sum = 0
+            if multipliers:
+                for variable, multiplier in zip(variables, multipliers):
+                    sum += assignments[variable] * multiplier
+            else:
+                for variable in variables:
+                    sum += assignments[variable]
+            if type(sum) is float:
+                sum = round(sum, 10)
+            return sum >= minsum
+
+
+class InSetConstraint(Constraint):
+    """
+    Constraint enforcing that values of given variables are present in
+    the given set
+
+    Example:
+
+    >>> problem = Problem()
+    >>> problem.addVariables(["a", "b"], [1, 2])
+    >>> problem.addConstraint(InSetConstraint([1]))
+    >>> sorted(sorted(x.items()) for x in problem.getSolutions())
+    [[('a', 1), ('b', 1)]]
+    """
+
+    def __init__(self, set):
+        """
+        @param set: Set of allowed values
+        @type  set: set
+        """
+        self._set = set
+
+    def __call__(self, variables, domains, assignments, forwardcheck=False):
+        # preProcess() will remove it.
+        raise RuntimeError("Can't happen")
+
+    def preProcess(self, variables, domains, constraints, vconstraints):
+        set = self._set
+        for variable in variables:
+            domain = domains[variable]
+            for value in domain[:]:
+                if value not in set:
+                    domain.remove(value)
+            vconstraints[variable].remove((self, variables))
+        constraints.remove((self, variables))
+
+
+class NotInSetConstraint(Constraint):
+    """
+    Constraint enforcing that values of given variables are not present in
+    the given set
+
+    Example:
+
+    >>> problem = Problem()
+    >>> problem.addVariables(["a", "b"], [1, 2])
+    >>> problem.addConstraint(NotInSetConstraint([1]))
+    >>> sorted(sorted(x.items()) for x in problem.getSolutions())
+    [[('a', 2), ('b', 2)]]
+    """
+
+    def __init__(self, set):
+        """
+        @param set: Set of disallowed values
+        @type  set: set
+        """
+        self._set = set
+
+    def __call__(self, variables, domains, assignments, forwardcheck=False):
+        # preProcess() will remove it.
+        raise RuntimeError("Can't happen")
+
+    def preProcess(self, variables, domains, constraints, vconstraints):
+        set = self._set
+        for variable in variables:
+            domain = domains[variable]
+            for value in domain[:]:
+                if value in set:
+                    domain.remove(value)
+            vconstraints[variable].remove((self, variables))
+        constraints.remove((self, variables))
+
+
+class SomeInSetConstraint(Constraint):
+    """
+    Constraint enforcing that at least some of the values of given
+    variables must be present in a given set
+
+    Example:
+
+    >>> problem = Problem()
+    >>> problem.addVariables(["a", "b"], [1, 2])
+    >>> problem.addConstraint(SomeInSetConstraint([1]))
+    >>> sorted(sorted(x.items()) for x in problem.getSolutions())
+    [[('a', 1), ('b', 1)], [('a', 1), ('b', 2)], [('a', 2), ('b', 1)]]
+    """
+
+    def __init__(self, set, n=1, exact=False):
+        """
+        @param set: Set of values to be checked
+        @type  set: set
+        @param n: Minimum number of assigned values that should be present
+                  in set (default is 1)
+        @type  n: int
+        @param exact: Whether the number of assigned values which are
+                      present in set must be exactly C{n}
+        @type  exact: bool
+        """
+        self._set = set
+        self._n = n
+        self._exact = exact
+
+    def __call__(self, variables, domains, assignments, forwardcheck=False):
+        set = self._set
+        missing = 0
+        found = 0
+        for variable in variables:
+            if variable in assignments:
+                found += assignments[variable] in set
+            else:
+                missing += 1
+        if missing:
+            if self._exact:
+                if not (found <= self._n <= missing + found):
+                    return False
+            else:
+                if self._n > missing + found:
+                    return False
+            if forwardcheck and self._n - found == missing:
+                # All unassigned variables must be assigned to
+                # values in the set.
+                for variable in variables:
+                    if variable not in assignments:
+                        domain = domains[variable]
+                        for value in domain[:]:
+                            if value not in set:
+                                domain.hideValue(value)
+                        if not domain:
+                            return False
+        else:
+            if self._exact:
+                if found != self._n:
+                    return False
+            else:
+                if found < self._n:
+                    return False
+        return True
+
+
+class SomeNotInSetConstraint(Constraint):
+    """
+    Constraint enforcing that at least some of the values of given
+    variables must not be present in a given set
+
+    Example:
+
+    >>> problem = Problem()
+    >>> problem.addVariables(["a", "b"], [1, 2])
+    >>> problem.addConstraint(SomeNotInSetConstraint([1]))
+    >>> sorted(sorted(x.items()) for x in problem.getSolutions())
+    [[('a', 1), ('b', 2)], [('a', 2), ('b', 1)], [('a', 2), ('b', 2)]]
+    """
+
+    def __init__(self, set, n=1, exact=False):
+        """
+        @param set: Set of values to be checked
+        @type  set: set
+        @param n: Minimum number of assigned values that should not be present
+                  in set (default is 1)
+        @type  n: int
+        @param exact: Whether the number of assigned values which are
+                      not present in set must be exactly C{n}
+        @type  exact: bool
+        """
+        self._set = set
+        self._n = n
+        self._exact = exact
+
+    def __call__(self, variables, domains, assignments, forwardcheck=False):
+        set = self._set
+        missing = 0
+        found = 0
+        for variable in variables:
+            if variable in assignments:
+                found += assignments[variable] not in set
+            else:
+                missing += 1
+        if missing:
+            if self._exact:
+                if not (found <= self._n <= missing + found):
+                    return False
+            else:
+                if self._n > missing + found:
+                    return False
+            if forwardcheck and self._n - found == missing:
+                # All unassigned variables must be assigned to
+                # values not in the set.
+                for variable in variables:
+                    if variable not in assignments:
+                        domain = domains[variable]
+                        for value in domain[:]:
+                            if value in set:
+                                domain.hideValue(value)
+                        if not domain:
+                            return False
+        else:
+            if self._exact:
+                if found != self._n:
+                    return False
+            else:
+                if found < self._n:
+                    return False
+        return True
+
+
+if __name__ == "__main__":
+    import doctest
+    doctest.testmod()

--- a/frontend/constraint/version.py
+++ b/frontend/constraint/version.py
@@ -1,0 +1,8 @@
+__author__ = "Gustavo Niemeyer"
+__copyright__ = "Copyright (c) 2005-2014 - Gustavo Niemeyer <gustavo@niemeyer.net>"
+__credits__ = ["Sebastien Celles"]
+__license__ = ""
+__version__ = "1.3.1"
+__email__ = "gustavo@niemeyer.net"
+__status__ = "Development"
+__url__ = 'https://github.com/python-constraint/python-constraint'

--- a/frontend/i_types.py
+++ b/frontend/i_types.py
@@ -161,7 +161,10 @@ class Generic(list, Type):
         return hash(self.get_name())
 
     def get_name(self):
-        return "Generic" + str(self)
+        return "Generic[" + ",".join([x.get_name() for x in self]) + "]"
+
+    def __str__(self):
+        return self.get_name()
 
     def __init__(self, set, variable=None, constraint_problem=None):
         """

--- a/frontend/i_types.py
+++ b/frontend/i_types.py
@@ -413,8 +413,8 @@ class TDictionary(TObject):
             return True
         if type(t) in [TObject, Type]:
             return True
-        return (isinstance(t, TDictionary) and isinstance(self.key_type, type(t.key_type))
-                and isinstance(self.value_type, type(t.value_type)))
+        return (isinstance(t, TDictionary) and self.key_type.is_subtype(t.key_type)
+                and self.value_type.is_subtype(t.value_type))
 
     def get_name(self):
         return "{}({}:{})".format(self.name, self.key_type.get_name(), self.value_type.get_name())

--- a/frontend/stmt_inferrer.py
+++ b/frontend/stmt_inferrer.py
@@ -12,6 +12,10 @@ Infers the types for the following expressions:
     - With(withitem* items, stmt* body)
     - AsyncWith(withitem* items, stmt* body)
     - Try(stmt* body, excepthandler* handlers, stmt* orelse, stmt* finalbody)
+    - FunctionDef(identifier name, arguments args,
+                       stmt* body, expr* decorator_list, expr? returns)
+    - AsyncFunctionDef(identifier name, arguments args,
+                             stmt* body, expr* decorator_list, expr? returns)
 
     TODO:
     - Import(alias* names)
@@ -26,6 +30,7 @@ import frontend.predicates as pred
 import sys
 
 from frontend.i_types import *
+from frontend.constraint.constraint import *
 
 
 def _infer_assignment_target(target, context, value_type):
@@ -56,6 +61,9 @@ def _infer_assignment_target(target, context, value_type):
             elif not value_type.is_subtype(var_type):
                 raise TypeError("The type of {} is {}. Cannot assign it to {}.".format(target.id, var_type, value_type))
         else:
+            if isinstance(value_type, Generic) and not value_type.variable:
+                # Happens only when the target is an iteration target
+                value_type.setVariable(target.id)
             context.set_type(target.id, value_type)
 
     elif isinstance(target, ast.Tuple) or isinstance(target, ast.List):  # Tuple/List assignment
@@ -113,7 +121,7 @@ def _infer_assign(node, context, constraint_problem):
     return TNone()
 
 
-def _infer_augmented_assign(node, context):
+def _infer_augmented_assign(node, context, constraint_problem):
     """Infer the types for augmented assignments
 
     Examples:
@@ -122,14 +130,14 @@ def _infer_augmented_assign(node, context):
 
     TODO: Attribute augmented assignment
     """
-    target_type = expr.infer(node.target, context)
-    value_type = expr.infer(node.value, context)
-    result_type = expr.binary_operation_type(target_type, node.op, value_type)
+    target_type = expr.infer(node.target, context, constraint_problem)
+    value_type = expr.infer(node.value, context, constraint_problem)
+    result_type = expr.binary_operation_type(target_type, node.op, value_type, constraint_problem)
     if isinstance(node.target, ast.Name):
         # If result_type was a supertype of target_type, replace it in the context
         context.set_type(node.target.id, result_type)
     elif isinstance(node.target, ast.Subscript):
-        indexed_type = expr.infer(node.target.value, context)
+        indexed_type = expr.infer(node.target.value, context, constraint_problem)
         if isinstance(indexed_type, TString):
             raise TypeError("String objects don't support item assignment.")
         elif isinstance(indexed_type, TTuple):
@@ -151,7 +159,7 @@ def _infer_augmented_assign(node, context):
     return TNone()
 
 
-def _delete_element(target, context):
+def _delete_element(target, context, constraint_problem):
     """Remove (if needed) a target from the context
 
     Cases:
@@ -163,33 +171,33 @@ def _delete_element(target, context):
     """
     if isinstance(target, (ast.Tuple, ast.List)):  # Multiple deletions
         for elem in target.elts:
-            _delete_element(elem, context)
+            _delete_element(elem, context, constraint_problem)
     elif isinstance(target, ast.Name):
         context.delete_type(target.id)
     elif isinstance(target, ast.Subscript):
-        indexed_type = expr.infer(target.value, context)
+        indexed_type = expr.infer(target.value, context, constraint_problem)
         if isinstance(indexed_type, TString):
             raise TypeError("String objects don't support item deletion.")
         elif isinstance(indexed_type, TTuple):
             raise TypeError("Tuple objects don't support item deletion.")
 
 
-def _infer_delete(node, context):
+def _infer_delete(node, context, constraint_problem):
     """Remove (if needed) the type of the deleted items in the current context"""
     for target in node.targets:
-        _delete_element(target, context)
+        _delete_element(target, context, constraint_problem)
 
     return TNone()
 
 
-def _infer_body(body, context):
+def _infer_body(body, context, constraints_problem):
     """Infer the type of a code block containing multiple statements"""
     body_type = TNone()
     for stmt in body:
-        stmt_type = infer(stmt, context)
-        if body_type.is_subtype(stmt_type):
+        stmt_type = infer(stmt, context, constraints_problem)
+        if body_type.is_subtype(stmt_type) or isinstance(body_type, TNone):
             body_type = stmt_type
-        elif not stmt_type.is_subtype(body_type):
+        elif not (stmt_type.is_subtype(body_type) or isinstance(stmt_type, TNone)):
             if isinstance(body_type, UnionTypes):
                 body_type.union(stmt_type)
             elif isinstance(stmt_type, UnionTypes):
@@ -201,7 +209,7 @@ def _infer_body(body, context):
     return body_type
 
 
-def _infer_control_flow(node, context):
+def _infer_control_flow(node, context, constraint_problem):
     """Infer the type(s) for an if/while/for statements block.
 
     Arguments:
@@ -217,8 +225,8 @@ def _infer_control_flow(node, context):
 
         type: Union{String, Float}
     """
-    body_type = _infer_body(node.body, context)
-    else_type = _infer_body(node.orelse, context)
+    body_type = _infer_body(node.body, context, constraint_problem)
+    else_type = _infer_body(node.orelse, context, constraint_problem)
 
     if body_type.is_subtype(else_type):
         return else_type
@@ -234,7 +242,7 @@ def _infer_control_flow(node, context):
     return UnionTypes({body_type, else_type})
 
 
-def _infer_for(node, context):
+def _infer_for(node, context, constraint_problem):
     """Infer the type for a for loop node
 
     Limitation:
@@ -243,73 +251,125 @@ def _infer_for(node, context):
                 for x in (1, 2.0, "string"):
                     ....
     """
-    iter_type = expr.infer(node.iter, context)
-    if not isinstance(iter_type, (TList, TSet, TIterator, TBytesString, TDictionary, TString)):
-        raise TypeError("The iterable should only be a set, list or iterator. Found {}.".format(iter_type))
+    iter_type = expr.infer(node.iter, context, constraint_problem)
+    value_type = iter_type
+    if isinstance(iter_type, Generic):
+        value_type = key_type = Generic([Type()], constraint_problem=constraint_problem)
+        iter_type.narrow([TSequence(), TDictionary(t_k=key_type), TSet(t=key_type)])
+    elif not isinstance(iter_type, (TList, TSet, TIterator, TBytesString, TDictionary, TString)):
+        raise TypeError("{} is not iterable.".format(iter_type))
 
     # Infer the target in the loop, inside the global context
     # Cases:
     # - Var name. Ex: for i in range(5)..
     # - Tuple. Ex: for (a,b) in [(1,"st"), (3,"st2")]..
     # - List. Ex: for [a,b] in [(1, "st"), (3, "st2")]..
-    value_type = iter_type
     if isinstance(iter_type, (TList, TSet, TIterator)):
         value_type = value_type.type
     elif isinstance(iter_type, TDictionary):
         value_type = value_type.key_type
+
     _infer_assignment_target(node.target, context, value_type)
 
-    return _infer_control_flow(node, context)
+    return _infer_control_flow(node, context, constraint_problem)
 
 
-def _infer_with(node, context):
+def _infer_with(node, context, constraint_problem):
     """Infer the types for a with block"""
     for item in node.items:
         if item.optional_vars:
-            item_type = expr.infer(item.context_expr, context)
+            item_type = expr.infer(item.context_expr, context, constraint_problem)
             _infer_assignment_target(item.optional_vars, context, item_type)
 
-    return _infer_body(node.body, context)
+    return _infer_body(node.body, context, constraint_problem)
 
 
-def _infer_try(node, context):
+def _infer_try(node, context, constraint_problem):
     """Infer the types for a try/except/else block"""
     try_type = UnionTypes()
 
-    try_type.union(_infer_body(node.body, context))
-    try_type.union(_infer_body(node.orelse, context))
-    try_type.union(_infer_body(node.finalbody, context))
+    try_type.union(_infer_body(node.body, context, constraint_problem))
+    try_type.union(_infer_body(node.orelse, context, constraint_problem))
+    try_type.union(_infer_body(node.finalbody, context, constraint_problem))
     # TODO: Infer exception handlers as classes
 
     for handler in node.handlers:
-        try_type.union(_infer_body(handler.body, context))
+        try_type.union(_infer_body(handler.body, context, constraint_problem))
 
     if len(try_type.types) == 1:
         return list(try_type.types)[0]
     return try_type
 
 
+def init_func_def(args, context):
+    """Initialize the local context of the function and the constraints problem for the args domains."""
+    # TODO handle starred args
+    function_context = Context(parent_context=context)
+    constraints_problem = Problem()
+
+    for arg in args:
+        # TODO use annotation if possible
+        domain = Generic([Type()], arg.arg, constraints_problem)
+        function_context.set_type(arg.arg, domain)
+        constraints_problem.addVariable(arg.arg, domain)
+
+    return function_context, constraints_problem
+
+
+def _narrow_with_constraints(t, solutions):
+    """Narrow a Generic type t based on values appearing in the constraints problem solutions"""
+    if not isinstance(t, Generic):
+        return
+    possible = []
+    for sol in solutions:
+        possible.append(sol[t.variable])
+    t.narrow(possible)
+
+
+def infer_func_def(node, context):
+    function_context, constraint_problem = init_func_def(node.args.args, context)
+    return_type = _infer_body(node.body, function_context, constraint_problem)
+
+    args_types = []
+    for arg in node.args.args:
+        args_types.append(function_context.get_type(arg.arg))
+
+    constraints_sols = constraint_problem.getSolutions()
+
+    _narrow_with_constraints(return_type, constraints_sols)
+    for arg_t in args_types:
+        _narrow_with_constraints(arg_t, constraints_sols)
+    function_type = TFunction(return_type, args_types, constraints_sols)
+    context.set_type(node.name, function_type)
+    return TNone()
+
+
 def infer(node, context, constraint_problem=None):
     if isinstance(node, ast.Assign):
         return _infer_assign(node, context, constraint_problem)
     elif isinstance(node, ast.AugAssign):
-        return _infer_augmented_assign(node, context)
+        return _infer_augmented_assign(node, context, constraint_problem)
     elif isinstance(node, ast.Return):
-        return expr.infer(node.value, context)
+        return expr.infer(node.value, context, constraint_problem)
     elif isinstance(node, ast.Delete):
-        return _infer_delete(node, context)
+        return _infer_delete(node, context, constraint_problem)
     elif isinstance(node, (ast.If, ast.While)):
-        return _infer_control_flow(node, context)
+        return _infer_control_flow(node, context, constraint_problem)
     elif isinstance(node, ast.For):
-        return _infer_for(node, context)
+        return _infer_for(node, context, constraint_problem)
     elif sys.version_info[0] >= 3 and sys.version_info[1] >= 5 and isinstance(node, ast.AsyncFor):
         # AsyncFor is introduced in Python 3.5
-        return _infer_for(node, context)
+        return _infer_for(node, context, constraint_problem)
     elif isinstance(node, ast.With):
-        return _infer_with(node, context)
+        return _infer_with(node, context, constraint_problem)
     elif sys.version_info[0] >= 3 and sys.version_info[1] >= 5 and isinstance(node, ast.AsyncWith):
         # AsyncWith is introduced in Python 3.5
-        return _infer_with(node, context)
+        return _infer_with(node, context, constraint_problem)
     elif isinstance(node, ast.Try):
-        return _infer_try(node, context)
+        return _infer_try(node, context, constraint_problem)
+    elif isinstance(node, ast.FunctionDef):
+        return infer_func_def(node, context)
+    elif sys.version_info[0] >= 3 and sys.version_info[1] >= 5 and isinstance(node, ast.AsyncFunctionDef):
+        # AsyncWith is introduced in Python 3.5
+        return infer_func_def(node, context)
     return TNone()

--- a/frontend/stmt_inferrer.py
+++ b/frontend/stmt_inferrer.py
@@ -57,6 +57,7 @@ def _infer_assignment_target(target, context, value_type):
                 raise TypeError("The type of {} is {}. Cannot assign it to {}.".format(target.id, var_type, value_type))
         else:
             context.set_type(target.id, value_type)
+
     elif isinstance(target, ast.Tuple) or isinstance(target, ast.List):  # Tuple/List assignment
         if not pred.is_sequence(value_type):
             raise ValueError("Cannot unpack a non sequence.")
@@ -102,10 +103,10 @@ def _infer_assignment_target(target, context, value_type):
         raise NotImplementedError("The inference for {} assignment is not supported.".format(type(target).__name__))
 
 
-def _infer_assign(node, context):
+def _infer_assign(node, context, constraint_problem):
     """Infer the types of target variables in an assignment node."""
-    value_type = expr.infer(node.value,
-                            context)  # The type of the value assigned to the targets in the assignment statement.
+    # The type of the value assigned to the targets in the assignment statement.
+    value_type = expr.infer(node.value, context, constraint_problem)
     for target in node.targets:
         _infer_assignment_target(target, context, value_type)
 
@@ -288,9 +289,9 @@ def _infer_try(node, context):
     return try_type
 
 
-def infer(node, context):
+def infer(node, context, constraint_problem=None):
     if isinstance(node, ast.Assign):
-        return _infer_assign(node, context)
+        return _infer_assign(node, context, constraint_problem)
     elif isinstance(node, ast.AugAssign):
         return _infer_augmented_assign(node, context)
     elif isinstance(node, ast.Return):

--- a/frontend/stmt_inferrer.py
+++ b/frontend/stmt_inferrer.py
@@ -336,7 +336,7 @@ def _narrow_with_constraints(t, solutions):
     t.narrow(possible)
 
 
-def infer_func_def(node, context):
+def function_type(node, context):
     function_context, constraint_problem = init_func_def(node.args.args, context)
     return_type = _infer_body(node.body, function_context, constraint_problem)
 
@@ -352,8 +352,12 @@ def infer_func_def(node, context):
     _narrow_with_constraints(return_type, constraints_sols)
     for arg_t in args_order_to_type:
         _narrow_with_constraints(arg_t.type, constraints_sols)
-    function_type = TFunction(return_type, args_name_to_type, args_order_to_type, constraints_sols)
-    context.set_type(node.name, function_type)
+    return TFunction(return_type, args_name_to_type, args_order_to_type, constraints_sols)
+
+
+def infer_func_def(node, context):
+    func_def_type = function_type(node, context)
+    context.set_type(node.name, func_def_type)
 
     return TNone()
 

--- a/frontend/stmt_inferrer.py
+++ b/frontend/stmt_inferrer.py
@@ -330,17 +330,21 @@ def infer_func_def(node, context):
     function_context, constraint_problem = init_func_def(node.args.args, context)
     return_type = _infer_body(node.body, function_context, constraint_problem)
 
-    args_types = []
+    args_order_to_type = []
+    args_name_to_type = {}
     for arg in node.args.args:
-        args_types.append(function_context.get_type(arg.arg))
+        arg_type = function_context.get_type(arg.arg)
+        args_order_to_type.append(FunctionArgumentType(arg.arg, arg_type))
+        args_name_to_type[arg.arg] = arg_type
 
     constraints_sols = constraint_problem.getSolutions()
 
     _narrow_with_constraints(return_type, constraints_sols)
-    for arg_t in args_types:
-        _narrow_with_constraints(arg_t, constraints_sols)
-    function_type = TFunction(return_type, args_types, constraints_sols)
+    for arg_t in args_order_to_type:
+        _narrow_with_constraints(arg_t.type, constraints_sols)
+    function_type = TFunction(return_type, args_name_to_type, args_order_to_type, constraints_sols)
     context.set_type(node.name, function_type)
+
     return TNone()
 
 

--- a/tests/function_def_test.py
+++ b/tests/function_def_test.py
@@ -1,0 +1,43 @@
+def f1(x):
+    return x
+
+
+def f2(x, y):
+    return x + y
+
+
+def f3(x, y):
+    return x * y
+
+
+def f4(x, y):
+    return x * y + 3
+
+
+def f5(x, y):
+    a = x["string"] + y
+    b = y + 3
+    return a | b
+
+
+def f6(a, b, i):
+    x = a * 3
+    y = b["string"]
+    z = a[i]
+    return (x[0] + z) * (y + 3)
+
+
+def f7(x):
+    return x["string"]
+
+
+a = f1(2.0)
+b = f2(1, 3)
+c = f2("st1", "st2")
+d = f3(3, [1, 2, 3])
+e = f3(2.0, 7)
+f = f3("st", 3)
+g = f4(2, 3)
+h = f5({"st": 2}, 3)
+i = f6([[3]], {"string": 1}, 2)
+j = f7({"string": 1})

--- a/tests/inference_runner.py
+++ b/tests/inference_runner.py
@@ -4,7 +4,7 @@ r = open("tests/expressions_test.py")
 t = ast.parse(r.read())
 context = Context()
 for stmt in t.body:
-    infer(stmt, context)
+    infer(stmt, context, None)
 
-for key in context.types_map:
+for key in sorted(context.types_map):
     print("{} : {}".format(key, context.types_map[key]))


### PR DESCRIPTION
Implemented FunctionDef and function call inference

- Used python-constraint library to add arguments type combination constraints in function definitions, and added modification to the library to extend the constraints to take the subtypes relationships between the domain elements into account. Added the source code for the modified library to the project and included its copyright notice.
 ```python
 def f(a, b):
     return a * b
 ```
The following combinations are allowed:
`a := Number, b:= Number`
`a := Number, b:= Sequence`
`a := Sequence, b:= Number`
The following is not allowed:
`a := Sequence, b:= Sequence`

- Implemented domain narrowing based on the type of the operation:
```python
def f(a, b, i):
    x = a * 3
    y = b["string"]
    z = a[i]
    return (x + z) * (y + 3)
```
The inference for the above functions will work as follows:
```
Args:
a := Sequence
b := Dict{str, Number}
i := int

Return:
Sequence
```

- Implemented generics unification:
```python
def f(x):
    return x

a = f(1)  # a := int
b = f("string")  # b:= str

def g(a):
   return a * 2

a = g(1)  # a := int
b = g([1,2])  # b := list[int]
```




