### PR TITLE
Added support for importing stubs and funcs with type vars

### DIFF
--- a/frontend/annotation_resolver.py
+++ b/frontend/annotation_resolver.py
@@ -152,14 +152,14 @@ class AnnotationResolver:
 
         raise ValueError("Invalid type annotation in line {}".format(annotation.lineno))
 
-    def add_annotated_function_axioms(self, args_types, solver, annotations, result_type):
+    def add_annotated_function_axioms(self, args_types, solver, annotated_function, result_type):
         """Add axioms for a function call to an annotated function
         
         Reprocess the type annotations for every function call to prevent binding a certain type
         to the function definition
         """
-        args_annotations = annotations[0]
-        result_annotation = annotations[1]
+        args_annotations = annotated_function.args_annotations
+        result_annotation = annotated_function.return_annotation
 
         if len(args_types) != len(args_annotations):
             raise TypeError("The function expects {} arguments. {} were given.".format(len(args_annotations),

--- a/frontend/context.py
+++ b/frontend/context.py
@@ -7,7 +7,6 @@ class Context:
 
     def __init__(self, parent_context=None):
         self.types_map = {}
-        self.annotated_functions = {}
         self.parent_context = parent_context
         self.children_contexts = []
 
@@ -63,19 +62,8 @@ class Context:
                 continue
         raise NameError("Name {} is not defined".format(var_name))
 
-    def has_annotated_func(self, func_name):
-        """Check if this context (or parent context) has an annotated function `func_name`"""
-        if func_name in self.annotated_functions:
-            return True
-        if self.parent_context is None:
-            return False
-        return self.parent_context.has_annotated_func(func_name)
 
-    def get_annotated_func(self, func_name):
-        """Get the annotated function `func_name` from this context (or a parent context)"""
-        if func_name in self.annotated_functions:
-            return self.annotated_functions[func_name]
-        if self.parent_context is None:
-            raise NameError("Name {} is not defined".format(func_name))
-        return self.parent_context.get_annotated_func(func_name)
-
+class AnnotatedFunction:
+    def __init__(self, args_annotations, return_annotation):
+        self.args_annotations = args_annotations
+        self.return_annotation = return_annotation

--- a/frontend/stmt_inferrer.py
+++ b/frontend/stmt_inferrer.py
@@ -26,7 +26,7 @@ import frontend.z3_axioms as axioms
 import frontend.z3_types as z3_types
 import sys
 
-from frontend.context import Context
+from frontend.context import Context, AnnotatedFunction
 from frontend.import_handler import ImportHandler
 
 
@@ -401,7 +401,7 @@ def _infer_func_def(node, context, solver):
         args_annotations = []
         for arg in node.args.args:
             args_annotations.append(arg.annotation)
-        context.annotated_functions[node.name] = (args_annotations, return_annotation)
+        context.set_type(node.name, AnnotatedFunction(args_annotations, return_annotation))
         return
 
     func_context, args_types = _init_func_context(node.args.args, context, solver)

--- a/tests/inference_runner.py
+++ b/tests/inference_runner.py
@@ -43,7 +43,7 @@ else:
     for v in sorted(context.types_map):
         z3_t = context.types_map[v]
 
-        if isinstance(z3_t, Context):
+        if isinstance(z3_t, (Context, AnnotatedFunction)):
             continue
 
         print("{}: {}".format(v, model[z3_t]))


### PR DESCRIPTION
Very little (but important changes) :)

- Added support for import stubs and type vars
- Wrapped the annotated function attributes in an object instead of tuple and added it into context (Cleaner and will make it easier to import built-in libraries later on)

For example, now it's possible to do the following:

file1.py
```python
from typing import TypeVar

T = TypeVar("T")

def f(x: T) -> T:
     pass
```

file2.py
```python
import file1

x = file1.f("s")
```