### PR TITLE
Used inference config to decide the inference strictness

### DIFF
--- a/frontend/config.py
+++ b/frontend/config.py
@@ -1,0 +1,14 @@
+config = {
+    # Whether to ignore the body of fully annotated functions and just take the provided types for args/return
+    "ignore_fully_annotated_function": False,
+
+    # Whether to allow different branches to use different types of same variable.
+    # Example:
+    # if _some_condition:
+    #       x = 1
+    #       x += 2
+    # else:
+    #       x = "string"
+    #       x += "a"
+    "enforce_same_type_in_branches": False,
+}

--- a/frontend/stmt_inferrer.py
+++ b/frontend/stmt_inferrer.py
@@ -26,6 +26,7 @@ import frontend.z3_axioms as axioms
 import frontend.z3_types as z3_types
 import sys
 
+from frontend.config import config as inference_config
 from frontend.context import Context, AnnotatedFunction
 from frontend.import_handler import ImportHandler
 
@@ -219,10 +220,15 @@ def _infer_control_flow(node, context, solver):
             var_type = solver.new_z3_const("branching_var")
             t1 = body_context.types_map[v]
             t2 = else_context.types_map[v]
-            solver.add(solver.z3_types.subtype(t1, var_type),
+
+            if inference_config["enforce_same_type_in_branches"]:
+                branch_axioms = [t1 == var_type, t2 == var_type]
+            else:
+                branch_axioms = [solver.z3_types.subtype(t1, var_type), solver.z3_types.subtype(t2, var_type)]
+
+            solver.add(branch_axioms,
                        fail_message="subtyping in flow branching in line {}".format(node.lineno))
-            solver.add(solver.z3_types.subtype(t2, var_type),
-                       fail_message="subtyping in flow branching in line {}".format(node.lineno))
+
             solver.optimize.add_soft(t1 == var_type)
             solver.optimize.add_soft(t2 == var_type)
             context.set_type(v, var_type)
@@ -417,14 +423,12 @@ def _infer_func_def(node, context, solver):
 
     if node.returns:
         return_type = solver.resolve_annotation(node.returns)
-        if ((len(node.body) == 1 and isinstance(node.body[0], ast.Pass))
-            or (len(node.body) == 2 and isinstance(node.body[0], ast.Expr) and isinstance(node.body[1], ast.Pass))):
-            # Stub function
+        if inference_config["ignore_fully_annotated_function"] and is_annotated(node):
             body_type = return_type
         else:
             body_type = _infer_body(node.body, func_context, node.lineno, solver)
-            solver.add(body_type == return_type,
-                       fail_message="Return type annotation in line {}".format(node.lineno))
+        solver.add(body_type == return_type,
+                   fail_message="Return type annotation in line {}".format(node.lineno))
     else:
         body_type = _infer_body(node.body, func_context, node.lineno, solver)
 


### PR DESCRIPTION
Closes #35 

I tested it manually, but didn't add unit tests because the smart parsing of tests comments is implemented in #27 which is not merged yet. Will add the unit tests once the PR is merged.

Also, I use global configurations, which assumes that the configurations will be the same for the files that are inferred in the same run. Do you think I should change it and make the configurations specific to only to the file being inferred?
The pros for such implementation is that it's simpler, shorter and cleaner.