### PR TITLE
Fixed not inferring the unary operand after Not operation

### DIFF
--- a/frontend/expr_inferrer.py
+++ b/frontend/expr_inferrer.py
@@ -224,10 +224,9 @@ def infer_unary_operation(node, context, solver):
 
     Examples: -5, not 1, ~2
     """
+    unary_type = infer(node.operand, context, solver)
     if isinstance(node.op, ast.Not):  # (not expr) always gives bool type
         return solver.z3_types.bool
-
-    unary_type = infer(node.operand, context, solver)
 
     if isinstance(node.op, ast.Invert):
         solver.add(axioms.unary_invert(unary_type, solver.z3_types),

--- a/unittests/inference/unary_test_not.py
+++ b/unittests/inference/unary_test_not.py
@@ -1,0 +1,6 @@
+x = [1, 2, 3]
+
+if not x["string"]:
+    pass
+
+# unsat


### PR DESCRIPTION
Example:
```python
x = [1, 2, 3]
if not x["string"]:
    ...
```
Should now give unsat.