### PR TITLE
fixed assignment of precursory states

### DIFF
--- a/src/lyra/engine/backward.py
+++ b/src/lyra/engine/backward.py
@@ -141,10 +141,10 @@ class BackwardInterpreter(Interpreter):
                     if pre_result:     # a precursory analysis was run
                         pre_states: List[Optional[State]] = pre_result.get_node_result(current)
                         if isinstance(self.precursory, ForwardInterpreter):
-                            pre_states = pre_states[1:]
+                            pre_states = pre_states[:-1]
                         else:
                             assert isinstance(self.precursory, BackwardInterpreter)
-                            pre_states = pre_states[:-1]
+                            pre_states = pre_states[1:]
                     else:              # no precursory analysis was run
                         pre_states: List[Optional[State]] = [None] * len(current.stmts)
 

--- a/src/lyra/semantics/semantics.py
+++ b/src/lyra/semantics/semantics.py
@@ -306,7 +306,6 @@ class BuiltInCallSemantics(CallSemantics):
         error = f"Call to {stmt.name} with unexpected number of arguments!"
         raise ValueError(error)
 
-
     def raise_semantics(self, stmt: Raise, state: State) -> State:
         """Semantics of raising an Error.
 


### PR DESCRIPTION
Just a small fix.
(Maybe it's a little bit confusing that you always check for BackwardInterpreter first in forward.py, but do it in the opposite order in backward.py)