### PR TITLE
[INRIA Internship] Dataframe Columns Usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,6 @@ ENV/
 
 # examples
 /src/lyra/tests/example.py
+
+# mac
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,6 @@ ENV/
 
 # generated docs
 /docs/_build/
+
+# examples
+/src/lyra/tests/example.py

--- a/src/lyra/abstract_domains/usage/dataframe_usage_domain.py
+++ b/src/lyra/abstract_domains/usage/dataframe_usage_domain.py
@@ -159,10 +159,9 @@ class DataFrameColumnUsageState(BoundedLattice, State):
             self.store[left] = {None: UsageLattice()}
             return self
 
-        self.store[left] = {}
         for idn in right.ids():
             # new variable `left` has the information of the columns in `idn`
-            self.store[left][right.key] = UsageLattice()
+            # self.store[left][right.key] = UsageLattice()
 
             if right.key in self.store[idn].keys():
                 continue

--- a/src/lyra/abstract_domains/usage/dataframe_usage_domain.py
+++ b/src/lyra/abstract_domains/usage/dataframe_usage_domain.py
@@ -150,10 +150,6 @@ class DataFrameColumnUsageState(BoundedLattice, State):
         return self
 
     def _substitute_variable(self, left: VariableIdentifier, right: Expression) -> 'DataFrameColumnUsageState':
-        if type(left) == type(right) and left == right:
-            self.store[left] = {None: UsageLattice()}
-            return self
-
         used = any(usage.is_top() for usage in self.store[left].values())
         scoped = any(usage.is_scoped() for usage in self.store[left].values())
         if used or scoped:
@@ -172,7 +168,9 @@ class DataFrameColumnUsageState(BoundedLattice, State):
 
                 # Also the new variable `left` has the information of the columns in `idn`
                 self.store[left][right.key] = UsageLattice().written()
+            return self
 
+        self.store[left] = {None: UsageLattice()}
         return self
 
     def _substitute_subscription(self, left: Subscription, right: Expression) -> 'DataFrameColumnUsageState':

--- a/src/lyra/abstract_domains/usage/dataframe_usage_domain.py
+++ b/src/lyra/abstract_domains/usage/dataframe_usage_domain.py
@@ -197,20 +197,6 @@ class DataFrameColumnUsageState(BoundedLattice, State):
             return self
         raise ValueError(f"Unexpected dropping of columns to {dataframe}!")
 
-    # def _concat_dataframes(self, dataframes: Expression):
-    #     if isinstance(dataframes, ListDisplay):
-    #         for df in dataframes.items:
-    #             df
-    #
-    #     return self
-    #
-    # def concat_dataframes(self, dataframes: Set[Expression]) -> 'DataFrameColumnUsageState':
-    #     if self.is_bottom():
-    #         return self
-    #     self.big_join([deepcopy(self)._concat_dataframes(df) for df in dataframes])
-    #     self.result = set()
-    #     return self
-
     def drop_dataframe_column(self, dataframes: Set[Expression], columns: Set[Expression]):
         if self.is_bottom():
             return self

--- a/src/lyra/abstract_domains/usage/dataframe_usage_domain.py
+++ b/src/lyra/abstract_domains/usage/dataframe_usage_domain.py
@@ -150,7 +150,7 @@ class DataFrameColumnUsageState(BoundedLattice, State):
         return self
 
     def _substitute_variable(self, left: VariableIdentifier, right: Expression) -> 'DataFrameColumnUsageState':
-        if left == right:
+        if type(left) == type(right) and left == right:
             self.store[left] = {None: UsageLattice()}
             return self
 

--- a/src/lyra/abstract_domains/usage/dataframe_usage_domain.py
+++ b/src/lyra/abstract_domains/usage/dataframe_usage_domain.py
@@ -173,7 +173,7 @@ class DataFrameColumnUsageState(BoundedLattice, State):
 
         # Clean it up variable if right is not a subscription
         if not isinstance(right, Subscription):
-            self.store[left] = {None: UsageLattice()}
+            self.store[left] = {None: UsageLattice().written()}
             return self
 
         for idn in right.ids():
@@ -183,7 +183,7 @@ class DataFrameColumnUsageState(BoundedLattice, State):
             state = self.store[left].get(right.key, self.store[left][None])
             self.store[idn][right.key] = UsageLattice() if state == UsageLattice().written() else state
 
-        self.store[left] = {None: UsageLattice()}
+        self.store[left] = {None: UsageLattice().written()}
         return self
 
     def _substitute_subscription(self, left: Subscription, right: Expression) -> 'DataFrameColumnUsageState':

--- a/src/lyra/abstract_domains/usage/dataframe_usage_domain.py
+++ b/src/lyra/abstract_domains/usage/dataframe_usage_domain.py
@@ -143,8 +143,10 @@ class DataFrameColumnUsageState(BoundedLattice, State):
     def output(self, output: Set[Expression]) -> 'State':
         # Clean it up variables marks as written
         for df in output:
-            if self.store.get(df) is not None:
-                self.store[df] = {k: v for k, v in self.store[df].items() if v != UsageLattice().written()}
+            if self.store.get(df) is None:
+                continue
+
+            self.store[df] = {k: v for k, v in self.store[df].items() if v != UsageLattice().written()}
 
         return super().output(output)
 

--- a/src/lyra/core/expressions.py
+++ b/src/lyra/core/expressions.py
@@ -72,7 +72,7 @@ class Expression(metaclass=ABCMeta):
         :return: set of identifiers that appear in the expression
         """
         ids = set()
-        for expr in _walk(self):
+        for expr in walk(self):
             if isinstance(expr, VariableIdentifier):
                 ids.add(expr)
         return ids
@@ -93,7 +93,7 @@ def _iter_child_exprs(expr: Expression):
                     yield item
 
 
-def _walk(expr: Expression):
+def walk(expr: Expression):
     """
     Recursively yield all expressions in an expression tree
     starting at ``expr`` (including ``expr`` itself),

--- a/src/lyra/semantics/dataframe_usage_semantics.py
+++ b/src/lyra/semantics/dataframe_usage_semantics.py
@@ -1,6 +1,10 @@
+import itertools
+
 from lyra.abstract_domains.state import State
 from lyra.abstract_domains.usage.dataframe_usage_domain import DataFrameColumnUsageState
-from lyra.core.statements import Call
+from lyra.core.expressions import Subscription, Literal, VariableIdentifier, ListDisplay
+from lyra.core.statements import Call, SubscriptionAccess
+from lyra.core.types import StringLyraType, ListLyraType, SetLyraType, DictLyraType, TupleLyraType, DataFrameLyraType
 from lyra.engine.interpreter import Interpreter
 from lyra.semantics.backward import DefaultPandasBackwardSemantics
 
@@ -8,16 +12,56 @@ from lyra.semantics.backward import DefaultPandasBackwardSemantics
 class DataFrameColumnUsageSemantics(DefaultPandasBackwardSemantics):
     """Backward semantics of statements with support for Pandas library calls for dataframe column usage analysis."""
 
-    def drop_call_semantics(self, stmt: Call, state: DataFrameColumnUsageState, interpreter: Interpreter) -> DataFrameColumnUsageState:
+    def _summarized_view(self, stmt: Call, state: DataFrameColumnUsageState,
+                         interpreter: Interpreter) -> DataFrameColumnUsageState:
+        dfs = self.semantics(stmt.arguments[0], state, interpreter).result
+        return state.output(dfs)
+
+    def subscription_access_semantics(self, stmt: SubscriptionAccess, state: DataFrameColumnUsageState,
+                                      interpreter: Interpreter) -> DataFrameColumnUsageState:
+        target = self.semantics(stmt.target, state, interpreter).result
+        key = self.semantics(stmt.key, state, interpreter).result
+        result = set()
+        for primary, index in itertools.product(target, key):
+            if isinstance(primary.typ, DataFrameLyraType):
+                if isinstance(index, ListDisplay):
+                    for idx in index.items:
+                        subscription = Subscription(primary.typ, primary, idx)
+                        result.add(subscription)
+                elif isinstance(index, Literal):
+                    subscription = Subscription(primary.typ, primary, index)
+                    result.add(subscription)
+                else:
+                    error = f"Semantics for subscription of {primary} and {index} is not yet implemented!"
+                    raise NotImplementedError(error)
+            else:
+                error = f"Semantics for subscription of {primary} is not yet implemented!"
+                raise NotImplementedError(error)
+        state.result = result
+        return state
+
+    def drop_call_semantics(self, stmt: Call, state: DataFrameColumnUsageState,
+                            interpreter: Interpreter) -> DataFrameColumnUsageState:
         dataframes = self.semantics(stmt.arguments[0], state, interpreter).result
         columns = self.semantics(stmt.arguments[1], state, interpreter).result
         return state.drop_dataframe_column(dataframes, columns)
 
-    def head_call_semantics(self, stmt: Call, state: DataFrameColumnUsageState, interpreter: Interpreter) -> DataFrameColumnUsageState:
-        dataframes = self.semantics(stmt.arguments[0], state, interpreter).result
-        return state.output(dataframes)
+    def head_call_semantics(self, stmt: Call, state: DataFrameColumnUsageState,
+                            interpreter: Interpreter) -> DataFrameColumnUsageState:
+        return self._summarized_view(stmt, state, interpreter)
 
-    def read_csv_call_semantics(self, stmt: Call, state: DataFrameColumnUsageState, interpreter: Interpreter) -> DataFrameColumnUsageState:
-        return state    # TODO
+    def tail_call_semantics(self, stmt: Call, state: DataFrameColumnUsageState,
+                            interpreter: Interpreter) -> DataFrameColumnUsageState:
+        return self._summarized_view(stmt, state, interpreter)
 
+    def describe_call_semantics(self, stmt: Call, state: DataFrameColumnUsageState,
+                                interpreter: Interpreter) -> DataFrameColumnUsageState:
+        return self._summarized_view(stmt, state, interpreter)
 
+    def info_call_semantics(self, stmt: Call, state: DataFrameColumnUsageState,
+                            interpreter: Interpreter) -> DataFrameColumnUsageState:
+        return self._summarized_view(stmt, state, interpreter)
+
+    def read_csv_call_semantics(self, stmt: Call, state: DataFrameColumnUsageState,
+                                interpreter: Interpreter) -> DataFrameColumnUsageState:
+        return state  # TODO

--- a/src/lyra/semantics/dataframe_usage_semantics.py
+++ b/src/lyra/semantics/dataframe_usage_semantics.py
@@ -92,6 +92,16 @@ class DataFrameColumnUsageSemantics(DefaultPandasBackwardSemantics):
     ) -> DataFrameColumnUsageState:
         return self._summarized_view(stmt, state, interpreter)
 
+    def min_call_semantics(
+            self, stmt: Call, state: DataFrameColumnUsageState, interpreter: Interpreter
+    ) -> DataFrameColumnUsageState:
+        return state
+
+    def max_call_semantics(
+            self, stmt: Call, state: DataFrameColumnUsageState, interpreter: Interpreter
+    ) -> DataFrameColumnUsageState:
+        return state
+
     def read_csv_call_semantics(
             self, stmt: Call, state: DataFrameColumnUsageState, interpreter: Interpreter
     ) -> DataFrameColumnUsageState:

--- a/src/lyra/semantics/dataframe_usage_semantics.py
+++ b/src/lyra/semantics/dataframe_usage_semantics.py
@@ -25,14 +25,6 @@ class DataFrameColumnUsageSemantics(DefaultPandasBackwardSemantics):
         dfs = self.semantics(stmt.arguments[0], state, interpreter).result
         return state.output(dfs)
 
-    def slicing_access_semantics(
-            self,
-            stmt: SlicingAccess,
-            state: DataFrameColumnUsageState,
-            interpreter: Interpreter,
-    ) -> DataFrameColumnUsageState:
-        return state
-
     def subscription_access_semantics(
             self,
             stmt: SubscriptionAccess,
@@ -48,7 +40,6 @@ class DataFrameColumnUsageSemantics(DefaultPandasBackwardSemantics):
                     f"Semantics for subscription of {primary} is not yet implemented!"
                 )
                 raise NotImplementedError(error)
-
             if isinstance(index, ListDisplay):
                 for idx in index.items:
                     subscription = Subscription(primary.typ, primary, idx)
@@ -56,8 +47,6 @@ class DataFrameColumnUsageSemantics(DefaultPandasBackwardSemantics):
             elif isinstance(index, (Literal, VariableIdentifier)):
                 subscription = Subscription(primary.typ, primary, index)
                 result.add(subscription)
-            elif isinstance(index, BinaryArithmeticOperation):
-                ...
             else:
                 error = f"Semantics for subscription of {primary} and {index} is not yet implemented!"
                 raise NotImplementedError(error)
@@ -123,11 +112,6 @@ class DataFrameColumnUsageSemantics(DefaultPandasBackwardSemantics):
     ) -> DataFrameColumnUsageState:
         dfs = self.semantics(stmt.arguments[0], state, interpreter).result
         state.result = {df for df in dfs}
-        return state
-
-    def concat_call_semantics(self, stmt: Call, state: DataFrameColumnUsageState,
-                              interpreter: Interpreter) -> DataFrameColumnUsageState:
-        dfs = self.semantics(stmt.arguments[1], state, interpreter).result
         return state
 
     def replace_call_semantics(self, stmt: Call, state: DataFrameColumnUsageState,

--- a/src/lyra/semantics/dataframe_usage_semantics.py
+++ b/src/lyra/semantics/dataframe_usage_semantics.py
@@ -20,24 +20,24 @@ class DataFrameColumnUsageSemantics(DefaultPandasBackwardSemantics):
     """Backward semantics of statements with support for Pandas library calls for dataframe column usage analysis."""
 
     def _summarized_view(
-        self, stmt: Call, state: DataFrameColumnUsageState, interpreter: Interpreter
+            self, stmt: Call, state: DataFrameColumnUsageState, interpreter: Interpreter
     ) -> DataFrameColumnUsageState:
         dfs = self.semantics(stmt.arguments[0], state, interpreter).result
         return state.output(dfs)
 
     def slicing_access_semantics(
-        self,
-        stmt: SlicingAccess,
-        state: DataFrameColumnUsageState,
-        interpreter: Interpreter,
+            self,
+            stmt: SlicingAccess,
+            state: DataFrameColumnUsageState,
+            interpreter: Interpreter,
     ) -> DataFrameColumnUsageState:
         return state
 
     def subscription_access_semantics(
-        self,
-        stmt: SubscriptionAccess,
-        state: DataFrameColumnUsageState,
-        interpreter: Interpreter,
+            self,
+            stmt: SubscriptionAccess,
+            state: DataFrameColumnUsageState,
+            interpreter: Interpreter,
     ) -> DataFrameColumnUsageState:
         target = self.semantics(stmt.target, state, interpreter).result
         key = self.semantics(stmt.key, state, interpreter).result
@@ -49,6 +49,9 @@ class DataFrameColumnUsageSemantics(DefaultPandasBackwardSemantics):
                         subscription = Subscription(primary.typ, primary, idx)
                         result.add(subscription)
                 elif isinstance(index, Literal):
+                    subscription = Subscription(primary.typ, primary, index)
+                    result.add(subscription)
+                elif isinstance(index, VariableIdentifier):
                     subscription = Subscription(primary.typ, primary, index)
                     result.add(subscription)
                 else:
@@ -63,33 +66,45 @@ class DataFrameColumnUsageSemantics(DefaultPandasBackwardSemantics):
         return state
 
     def drop_call_semantics(
-        self, stmt: Call, state: DataFrameColumnUsageState, interpreter: Interpreter
+            self, stmt: Call, state: DataFrameColumnUsageState, interpreter: Interpreter
     ) -> DataFrameColumnUsageState:
         dataframes = self.semantics(stmt.arguments[0], state, interpreter).result
         columns = self.semantics(stmt.arguments[1], state, interpreter).result
         return state.drop_dataframe_column(dataframes, columns)
 
     def head_call_semantics(
-        self, stmt: Call, state: DataFrameColumnUsageState, interpreter: Interpreter
+            self, stmt: Call, state: DataFrameColumnUsageState, interpreter: Interpreter
     ) -> DataFrameColumnUsageState:
         return self._summarized_view(stmt, state, interpreter)
 
     def tail_call_semantics(
-        self, stmt: Call, state: DataFrameColumnUsageState, interpreter: Interpreter
+            self, stmt: Call, state: DataFrameColumnUsageState, interpreter: Interpreter
     ) -> DataFrameColumnUsageState:
         return self._summarized_view(stmt, state, interpreter)
 
     def describe_call_semantics(
-        self, stmt: Call, state: DataFrameColumnUsageState, interpreter: Interpreter
+            self, stmt: Call, state: DataFrameColumnUsageState, interpreter: Interpreter
     ) -> DataFrameColumnUsageState:
         return self._summarized_view(stmt, state, interpreter)
 
     def info_call_semantics(
-        self, stmt: Call, state: DataFrameColumnUsageState, interpreter: Interpreter
+            self, stmt: Call, state: DataFrameColumnUsageState, interpreter: Interpreter
     ) -> DataFrameColumnUsageState:
         return self._summarized_view(stmt, state, interpreter)
 
     def read_csv_call_semantics(
-        self, stmt: Call, state: DataFrameColumnUsageState, interpreter: Interpreter
+            self, stmt: Call, state: DataFrameColumnUsageState, interpreter: Interpreter
     ) -> DataFrameColumnUsageState:
         return state  # TODO
+
+    def loc_call_semantics(
+            self, stmt: Call, state: DataFrameColumnUsageState, interpreter: Interpreter
+    ) -> DataFrameColumnUsageState:
+        dfs = self.semantics(stmt.arguments[0], state, interpreter).result
+        pass
+
+    def iloc_call_semantics(
+            self, stmt: Call, state: DataFrameColumnUsageState, interpreter: Interpreter
+    ) -> DataFrameColumnUsageState:
+        dfs = self.semantics(stmt.arguments[0], state, interpreter).result
+        pass

--- a/src/lyra/semantics/dataframe_usage_semantics.py
+++ b/src/lyra/semantics/dataframe_usage_semantics.py
@@ -3,8 +3,15 @@ import itertools
 from lyra.abstract_domains.state import State
 from lyra.abstract_domains.usage.dataframe_usage_domain import DataFrameColumnUsageState
 from lyra.core.expressions import Subscription, Literal, VariableIdentifier, ListDisplay
-from lyra.core.statements import Call, SubscriptionAccess
-from lyra.core.types import StringLyraType, ListLyraType, SetLyraType, DictLyraType, TupleLyraType, DataFrameLyraType
+from lyra.core.statements import Call, SubscriptionAccess, SlicingAccess
+from lyra.core.types import (
+    StringLyraType,
+    ListLyraType,
+    SetLyraType,
+    DictLyraType,
+    TupleLyraType,
+    DataFrameLyraType,
+)
 from lyra.engine.interpreter import Interpreter
 from lyra.semantics.backward import DefaultPandasBackwardSemantics
 
@@ -12,13 +19,26 @@ from lyra.semantics.backward import DefaultPandasBackwardSemantics
 class DataFrameColumnUsageSemantics(DefaultPandasBackwardSemantics):
     """Backward semantics of statements with support for Pandas library calls for dataframe column usage analysis."""
 
-    def _summarized_view(self, stmt: Call, state: DataFrameColumnUsageState,
-                         interpreter: Interpreter) -> DataFrameColumnUsageState:
+    def _summarized_view(
+        self, stmt: Call, state: DataFrameColumnUsageState, interpreter: Interpreter
+    ) -> DataFrameColumnUsageState:
         dfs = self.semantics(stmt.arguments[0], state, interpreter).result
         return state.output(dfs)
 
-    def subscription_access_semantics(self, stmt: SubscriptionAccess, state: DataFrameColumnUsageState,
-                                      interpreter: Interpreter) -> DataFrameColumnUsageState:
+    def slicing_access_semantics(
+        self,
+        stmt: SlicingAccess,
+        state: DataFrameColumnUsageState,
+        interpreter: Interpreter,
+    ) -> DataFrameColumnUsageState:
+        return state
+
+    def subscription_access_semantics(
+        self,
+        stmt: SubscriptionAccess,
+        state: DataFrameColumnUsageState,
+        interpreter: Interpreter,
+    ) -> DataFrameColumnUsageState:
         target = self.semantics(stmt.target, state, interpreter).result
         key = self.semantics(stmt.key, state, interpreter).result
         result = set()
@@ -35,33 +55,41 @@ class DataFrameColumnUsageSemantics(DefaultPandasBackwardSemantics):
                     error = f"Semantics for subscription of {primary} and {index} is not yet implemented!"
                     raise NotImplementedError(error)
             else:
-                error = f"Semantics for subscription of {primary} is not yet implemented!"
+                error = (
+                    f"Semantics for subscription of {primary} is not yet implemented!"
+                )
                 raise NotImplementedError(error)
         state.result = result
         return state
 
-    def drop_call_semantics(self, stmt: Call, state: DataFrameColumnUsageState,
-                            interpreter: Interpreter) -> DataFrameColumnUsageState:
+    def drop_call_semantics(
+        self, stmt: Call, state: DataFrameColumnUsageState, interpreter: Interpreter
+    ) -> DataFrameColumnUsageState:
         dataframes = self.semantics(stmt.arguments[0], state, interpreter).result
         columns = self.semantics(stmt.arguments[1], state, interpreter).result
         return state.drop_dataframe_column(dataframes, columns)
 
-    def head_call_semantics(self, stmt: Call, state: DataFrameColumnUsageState,
-                            interpreter: Interpreter) -> DataFrameColumnUsageState:
+    def head_call_semantics(
+        self, stmt: Call, state: DataFrameColumnUsageState, interpreter: Interpreter
+    ) -> DataFrameColumnUsageState:
         return self._summarized_view(stmt, state, interpreter)
 
-    def tail_call_semantics(self, stmt: Call, state: DataFrameColumnUsageState,
-                            interpreter: Interpreter) -> DataFrameColumnUsageState:
+    def tail_call_semantics(
+        self, stmt: Call, state: DataFrameColumnUsageState, interpreter: Interpreter
+    ) -> DataFrameColumnUsageState:
         return self._summarized_view(stmt, state, interpreter)
 
-    def describe_call_semantics(self, stmt: Call, state: DataFrameColumnUsageState,
-                                interpreter: Interpreter) -> DataFrameColumnUsageState:
+    def describe_call_semantics(
+        self, stmt: Call, state: DataFrameColumnUsageState, interpreter: Interpreter
+    ) -> DataFrameColumnUsageState:
         return self._summarized_view(stmt, state, interpreter)
 
-    def info_call_semantics(self, stmt: Call, state: DataFrameColumnUsageState,
-                            interpreter: Interpreter) -> DataFrameColumnUsageState:
+    def info_call_semantics(
+        self, stmt: Call, state: DataFrameColumnUsageState, interpreter: Interpreter
+    ) -> DataFrameColumnUsageState:
         return self._summarized_view(stmt, state, interpreter)
 
-    def read_csv_call_semantics(self, stmt: Call, state: DataFrameColumnUsageState,
-                                interpreter: Interpreter) -> DataFrameColumnUsageState:
+    def read_csv_call_semantics(
+        self, stmt: Call, state: DataFrameColumnUsageState, interpreter: Interpreter
+    ) -> DataFrameColumnUsageState:
         return state  # TODO

--- a/src/lyra/semantics/dataframe_usage_semantics.py
+++ b/src/lyra/semantics/dataframe_usage_semantics.py
@@ -3,7 +3,7 @@ import itertools
 from lyra.abstract_domains.state import State
 from lyra.abstract_domains.usage.dataframe_usage_domain import DataFrameColumnUsageState
 from lyra.core.expressions import Subscription, Literal, VariableIdentifier, ListDisplay, BinaryArithmeticOperation
-from lyra.core.statements import Call, SubscriptionAccess, SlicingAccess
+from lyra.core.statements import Call, SubscriptionAccess, SlicingAccess, VariableAccess
 from lyra.core.types import (
     StringLyraType,
     ListLyraType,

--- a/src/lyra/semantics/dataframe_usage_semantics.py
+++ b/src/lyra/semantics/dataframe_usage_semantics.py
@@ -96,15 +96,3 @@ class DataFrameColumnUsageSemantics(DefaultPandasBackwardSemantics):
             self, stmt: Call, state: DataFrameColumnUsageState, interpreter: Interpreter
     ) -> DataFrameColumnUsageState:
         return state  # TODO
-
-    def loc_call_semantics(
-            self, stmt: Call, state: DataFrameColumnUsageState, interpreter: Interpreter
-    ) -> DataFrameColumnUsageState:
-        dfs = self.semantics(stmt.arguments[0], state, interpreter).result
-        pass
-
-    def iloc_call_semantics(
-            self, stmt: Call, state: DataFrameColumnUsageState, interpreter: Interpreter
-    ) -> DataFrameColumnUsageState:
-        dfs = self.semantics(stmt.arguments[0], state, interpreter).result
-        pass

--- a/src/lyra/semantics/dataframe_usage_semantics.py
+++ b/src/lyra/semantics/dataframe_usage_semantics.py
@@ -77,6 +77,11 @@ class DataFrameColumnUsageSemantics(DefaultPandasBackwardSemantics):
     ) -> DataFrameColumnUsageState:
         return self._summarized_view(stmt, state, interpreter)
 
+    def hist_call_semantics(
+            self, stmt: Call, state: DataFrameColumnUsageState, interpreter: Interpreter
+    ) -> DataFrameColumnUsageState:
+        return self._summarized_view(stmt, state, interpreter)
+
     def tail_call_semantics(
             self, stmt: Call, state: DataFrameColumnUsageState, interpreter: Interpreter
     ) -> DataFrameColumnUsageState:
@@ -95,11 +100,40 @@ class DataFrameColumnUsageSemantics(DefaultPandasBackwardSemantics):
     def min_call_semantics(
             self, stmt: Call, state: DataFrameColumnUsageState, interpreter: Interpreter
     ) -> DataFrameColumnUsageState:
+        dfs = self.semantics(stmt.arguments[0], state, interpreter).result
+        state.result = {df for df in dfs}
         return state
 
     def max_call_semantics(
             self, stmt: Call, state: DataFrameColumnUsageState, interpreter: Interpreter
     ) -> DataFrameColumnUsageState:
+        dfs = self.semantics(stmt.arguments[0], state, interpreter).result
+        state.result = {df for df in dfs}
+        return state
+
+    def median_call_semantics(
+            self, stmt: Call, state: DataFrameColumnUsageState, interpreter: Interpreter
+    ) -> DataFrameColumnUsageState:
+        dfs = self.semantics(stmt.arguments[0], state, interpreter).result
+        state.result = {df for df in dfs}
+        return state
+
+    def fillna_call_semantics(
+            self, stmt: Call, state: DataFrameColumnUsageState, interpreter: Interpreter
+    ) -> DataFrameColumnUsageState:
+        dfs = self.semantics(stmt.arguments[0], state, interpreter).result
+        state.result = {df for df in dfs}
+        return state
+
+    def concat_call_semantics(self, stmt: Call, state: DataFrameColumnUsageState,
+                              interpreter: Interpreter) -> DataFrameColumnUsageState:
+        dfs = self.semantics(stmt.arguments[1], state, interpreter).result
+        return state
+
+    def replace_call_semantics(self, stmt: Call, state: DataFrameColumnUsageState,
+                               interpreter: Interpreter) -> DataFrameColumnUsageState:
+        dfs = self.semantics(stmt.arguments[0], state, interpreter).result
+        state.result = {df for df in dfs}
         return state
 
     def read_csv_call_semantics(

--- a/src/lyra/tests/example.py
+++ b/src/lyra/tests/example.py
@@ -1,7 +1,0 @@
-import pandas as pd
-
-df: pd.DataFrame = pd.read_csv("data.csv")
-
-sub: pd.DataFrame = df[["First", "Second"]]
-sub.head()
-df.head()

--- a/src/lyra/tests/example.py
+++ b/src/lyra/tests/example.py
@@ -1,5 +1,7 @@
-
 import pandas as pd
-df: pd.DataFrame = pd.read_csv('bla.csv')
-df.drop('C', axis=1)
+
+df: pd.DataFrame = pd.read_csv("data.csv")
+
+sub: pd.DataFrame = df[["First", "Second"]]
+sub.head()
 df.head()

--- a/src/lyra/unittests/dataframe_tests.py
+++ b/src/lyra/unittests/dataframe_tests.py
@@ -1,0 +1,48 @@
+"""
+Data Usage Analysis Dataframes - Unit Tests
+======================================
+
+:Authors: Caterina Urban and Kevin Pinochet
+"""
+
+
+import glob
+import os
+import unittest
+
+import sys
+
+from lyra.abstract_domains.usage.dataframe_usage_domain import DataFrameColumnUsageState
+from lyra.engine.backward import BackwardInterpreter
+from lyra.semantics.dataframe_usage_semantics import DataFrameColumnUsageSemantics
+from lyra.unittests.runner import TestRunner
+
+
+class UsageTest(TestRunner):
+
+    def interpreter(self):
+        return BackwardInterpreter(self.cfgs, self.fargs, DataFrameColumnUsageSemantics(), 3)
+
+    def state(self):
+        return DataFrameColumnUsageState(self.variables)
+
+def test_suite():
+    suite = unittest.TestSuite()
+    name = os.getcwd() + '/usage/dataframes/**.py'
+    for path in glob.iglob(name):
+        if os.path.basename(path) != "__init__.py":
+            print(os.path.basename(path))
+            suite.addTest(UsageTest(path))
+    # name = os.getcwd() + '/usage/fulara/**.py'
+    # for path in glob.iglob(name):
+    #     if os.path.basename(path) != "__init__.py":
+    #         print('fulara/' + os.path.basename(path))
+    #         suite.addTest(FularaIntervalUsageTest(path))
+    return suite
+
+
+if __name__ == '__main__':
+    runner = unittest.TextTestRunner()
+    result = runner.run(test_suite())
+    if not result.wasSuccessful():
+        sys.exit(1)

--- a/src/lyra/unittests/usage/dataframes/handcraft_example_1.py
+++ b/src/lyra/unittests/usage/dataframes/handcraft_example_1.py
@@ -1,0 +1,12 @@
+import pandas as pd
+
+# INITIAL: df -> {_: W}
+df: pd.DataFrame = pd.read_csv("...")
+
+# STATE: df -> {"id": N, "t": U, _: N}
+df.drop(['id'], axis=1, inplace=True)
+
+# STATE: df -> {"t": U, _: N}
+df["t"].head()
+
+# FINAL: df -> {_: N}

--- a/src/lyra/unittests/usage/dataframes/handcraft_example_2.py
+++ b/src/lyra/unittests/usage/dataframes/handcraft_example_2.py
@@ -1,0 +1,18 @@
+import pandas as pd
+
+# STATE: df -> {_: W}
+df: pd.DataFrame = pd.read_csv("...")
+
+# STATE: df -> {"Latitude": U, "Longitude": U, "rot_15_x": W, "rot_30_x": W, "rot_45_x": W, _: U}
+df['rot_15_x'] = 0.96 * df['Longitude'] + 0.25 * df['Latitude']
+
+# STATE: df -> {"Latitude": U, "Longitude": U, "rot_30_x": W, "rot_45_x": W, _: U}
+df['rot_30_x'] = 0.86 * df['Longitude'] + 0.49 * df['Latitude']
+
+# STATE: df -> {"Latitude": U, "Longitude": U, "rot_45_x": W, _: U}
+df['rot_45_x'] = 0.71 * df['Longitude'] + 0.71 * df['Latitude']
+
+# STATE: df -> {_: U}
+df.head()
+
+# FINAL: df -> {_: N}

--- a/src/lyra/unittests/usage/dataframes/handcraft_example_3.py
+++ b/src/lyra/unittests/usage/dataframes/handcraft_example_3.py
@@ -1,0 +1,18 @@
+import pandas as pd
+
+# INITIAL: df -> {_: W}
+df: pd.DataFrame = pd.read_csv("data.csv")
+
+# STATE: df -> {"Column": N, "First": U, "Second": U, "Some": N, "Third": U, _: N}
+df[["Second", "Third"]].info()
+
+# STATE: df -> {"Column": N, "First": U, "Some": N, _: N}
+df["First"].info()
+
+# STATE: df -> {"Column": N, "First": N, "Some": N, _: N}
+df.drop("First", axis=1)
+
+# STATE: df -> {"Column": N, "Some": N, _: N}
+df.drop(["Some", "Column"], axis=1)
+
+# FINAL: df -> {_: N}

--- a/src/lyra/unittests/usage/dataframes/handcraft_example_4.py
+++ b/src/lyra/unittests/usage/dataframes/handcraft_example_4.py
@@ -1,0 +1,12 @@
+import pandas as pd
+
+# INITIAL: df -> {_: W}; sub -> {_: W}
+df: pd.DataFrame = pd.read_csv("...")
+
+# STATE: df -> {"A": U, "B": U, "C": U, _: N}; sub -> {_: W}
+sub: pd.DataFrame = df[["A", "B", "C"]]
+
+# STATE: df -> {_: N}; sub -> {_: U}
+sub.head()
+
+# FINAL: df -> {_: N}; sub -> {_: N}

--- a/src/lyra/unittests/usage/dataframes/handcraft_example_5.py
+++ b/src/lyra/unittests/usage/dataframes/handcraft_example_5.py
@@ -1,0 +1,15 @@
+import pandas as pd
+
+# INITIAL: df -> {_: W}; sub -> {_: W}
+df: pd.DataFrame = pd.read_csv("...")
+
+# STATE: df -> {"A": U, "B": N, "C": U, _: N}; sub -> {_: W}
+sub: pd.DataFrame = df[["A", "B", "C"]]
+
+# STATE: df -> {_: N}; sub -> {"B": W, _: U}
+sub["B"] = 1
+
+# STATE: df -> {_: N}; sub -> {_: U}
+sub.head()
+
+# FINAL: df -> {_: N}; sub -> {_: N}

--- a/src/lyra/unittests/usage/dataframes/handcraft_example_6.py
+++ b/src/lyra/unittests/usage/dataframes/handcraft_example_6.py
@@ -1,0 +1,18 @@
+import pandas as pd
+
+# INITIAL: df -> {_: W}; norm_df -> {_: W}
+df: pd.DataFrame = pd.read_csv("...")
+
+# STATE: df -> {"norm_x1": W, "norm_x2": W, "x1": U, "x2": U, _: N}; norm_df -> {_: W}
+df["norm_x1"] = (df["x1"] - df["x1"].min()) / (df["x1"].max() - df["x1"].min())
+
+# STATE: df -> {"norm_x1": U, "norm_x2": W, "x2": U, _: N}; norm_df -> {_: W}
+df["norm_x2"] = (df["x2"] - df["x2"].min()) / (df["x2"].max() - df["x2"].min())
+
+# STATE: df -> {"norm_x1": U, "norm_x2": U, _: N}; norm_df -> {_: W}
+norm_df: pd.DataFrame = df[["norm_x1", "norm_x2"]]
+
+# STATE: df -> {_: N}; norm_df -> {_: U}
+norm_df.head()
+
+# FINAL: df -> {_: N}; norm_df -> {_: N}

--- a/src/lyra/unittests/usage/dataframes/handcraft_example_7.py
+++ b/src/lyra/unittests/usage/dataframes/handcraft_example_7.py
@@ -1,0 +1,18 @@
+import pandas as pd
+
+# INITIAL: df -> {_: W}
+df: pd.DataFrame = pd.read_csv("train.csv")
+
+# STATE: df -> {"f": U, "id": U, _: U}
+df.head()
+
+# STATE: df -> {"f": U, "id": N, "norm_f": W, _: N}
+df.drop(['id'], axis=1, inplace=True)
+
+# STATE: df -> {"f": U, "norm_f": W, _: N}
+df["norm_f"] = (df["f"] - df["f"].min()) / (df["f"].min() - df["f"].max())
+
+# STATE: df -> {"norm_f": U, _: N}
+df["norm_f"].head()
+
+# FINAL: df -> {_: N}

--- a/src/lyra/unittests/usage/dataframes/real_example_1.py
+++ b/src/lyra/unittests/usage/dataframes/real_example_1.py
@@ -3,17 +3,20 @@ import pandas as pd
 # STATE: orig -> {_: W}; train -> {_: W}
 train: pd.DataFrame = pd.read_csv('train.csv')
 
-# STATE: orig -> {_: W}; train -> {"gen": W, "id": N, "lat": U, "lon": U, _: U}
+# STATE: orig -> {_: W}; train -> {"gen": W, "id": N, "lat": U, "lon": U, _: W}
 train.drop('id', axis=1, inplace=True)
 
-# STATE: orig -> {_: W}; train -> {"gen": W, "lat": U, "lon": U, _: U}
+# STATE: orig -> {_: W}; train -> {"gen": W, "lat": U, "lon": U, _: W}
 orig: pd.DataFrame = pd.read_csv("original.csv")
 
-# STATE: orig -> {"gen": W, _: N}; train -> {"gen": W, "lat": U, "lon": U, _: U}
+# STATE: orig -> {"gen": W, _: N}; train -> {"gen": W, "lat": U, "lon": U, _: W}
 train['gen'] = 1
 
-# STATE: orig -> {"gen": W, _: N}; train -> {"lat": U, "lon": U, _: U}
+# STATE: orig -> {"gen": W, _: N}; train -> {"lat": U, "lon": U, _: W}
 orig['gen'] = 0
+
+# STATE: orig -> {_: N}; train -> {"lat": U, "lon": U, _: W}
+train = pd.concat([train, orig])
 
 # STATE: orig -> {_: N}; train -> {"lat": U, "lon": U, _: U}
 train.head()

--- a/src/lyra/unittests/usage/dataframes/real_example_1.py
+++ b/src/lyra/unittests/usage/dataframes/real_example_1.py
@@ -1,0 +1,27 @@
+import pandas as pd
+
+# STATE: orig -> {_: W}; train -> {_: W}
+train: pd.DataFrame = pd.read_csv('train.csv')
+
+# STATE: orig -> {_: W}; train -> {"gen": W, "id": N, "lat": U, "lon": U, _: U}
+train.drop('id', axis=1, inplace=True)
+
+# STATE: orig -> {_: W}; train -> {"gen": W, "lat": U, "lon": U, _: U}
+orig: pd.DataFrame = pd.read_csv("original.csv")
+
+# STATE: orig -> {"gen": W, _: N}; train -> {"gen": W, "lat": U, "lon": U, _: U}
+train['gen'] = 1
+
+# STATE: orig -> {"gen": W, _: N}; train -> {"lat": U, "lon": U, _: U}
+orig['gen'] = 0
+
+# STATE: orig -> {_: N}; train -> {"lat": U, "lon": U, _: U}
+train.head()
+
+# STATE: orig -> {_: N}; train -> {"lat": U, "lon": U, "r": W, _: U}
+train['r'] = train['lat'] + train['lon']
+
+# STATE: orig -> {_: N}; train -> {_: U}
+train.head()
+
+# FINAL: orig -> {_: N}; train -> {_: N}

--- a/src/lyra/unittests/usage/dataframes/real_example_2.py
+++ b/src/lyra/unittests/usage/dataframes/real_example_2.py
@@ -1,0 +1,39 @@
+import pandas as pd
+
+# INITIAL: df -> {_: W}
+df: pd.DataFrame = pd.read_csv('train.csv')
+
+# STATE: df -> {"Age": U, "FoodCourt": U, "Name": U, "PassengerId": U, "ShoppingMall": U, "Spa": U, "Transported": U, "VRDeck": U, _: U}
+df.head()
+
+# STATE: df -> {"Age": U, "FoodCourt": U, "Name": U, "PassengerId": U, "ShoppingMall": U, "Spa": U, "Transported": U, "VRDeck": U, _: U}
+df.describe()
+
+# STATE: df -> {"Age": U, "FoodCourt": U, "Name": U, "PassengerId": U, "ShoppingMall": U, "Spa": U, "Transported": U, "VRDeck": U, _: U}
+df.info()
+
+# STATE: df -> {"Age": U, "FoodCourt": U, "Name": N, "PassengerId": N, "ShoppingMall": U, "Spa": U, "Transported": U, "VRDeck": U, _: U}
+df["Transported"].hist()
+
+# STATE: df -> {"Age": U, "FoodCourt": U, "Name": N, "PassengerId": N, "ShoppingMall": U, "Spa": U, "VRDeck": U, _: U}
+df['Age'].hist(bins=50)
+
+# STATE: df -> {"FoodCourt": U, "Name": N, "PassengerId": N, "ShoppingMall": U, "Spa": U, "VRDeck": U, _: U}
+df['FoodCourt'].hist(bins=50)
+
+# STATE: df -> {"Name": N, "PassengerId": N, "ShoppingMall": U, "Spa": U, "VRDeck": U, _: U}
+df['ShoppingMall'].hist(bins=50)
+
+# STATE: df -> {"Name": N, "PassengerId": N, "Spa": U, "VRDeck": U, _: U}
+df['Spa'].hist(bins=50)
+
+# STATE: df -> {"Name": N, "PassengerId": N, "VRDeck": U, _: U}
+df['VRDeck'].hist(bins=50)
+
+# STATE: df -> {"Name": N, "PassengerId": N, _: U}
+df.drop(['PassengerId', 'Name'], axis=1, inplace=True)
+
+# STATE: df -> {_: U}
+df.head()
+
+# FINAL: df -> {_: N}

--- a/src/lyra/unittests/usage/dataframes/real_example_3.py
+++ b/src/lyra/unittests/usage/dataframes/real_example_3.py
@@ -1,0 +1,40 @@
+import pandas as pd
+
+# STATE: df -> {_: W}
+df: pd.DataFrame = pd.read_csv('train.csv')
+
+# STATE: df -> {"Age": U, "Cabin": U, "Embarked": U, "Fare": U, "Name": U, "Parch": U, "PassengerId": U, "SibSp": U, "Ticket": U, "Title": U, _: U}
+df.info()
+
+# STATE: df -> {"Age": U, "Cabin": N, "Embarked": U, "Fare": U, "Name": N, "Parch": U, "PassengerId": N, "PassengersInGroup": W, "SibSp": U, "Ticket": N, "Title": U, _: U}
+df['Age'] = df['Age'].fillna(df['Age'].median())
+
+# STATE: df -> {"Cabin": N, "Embarked": U, "Fare": U, "Name": N, "Parch": U, "PassengerId": N, "PassengersInGroup": W, "SibSp": U, "Ticket": N, "Title": U, _: U}
+df['Embarked'] = df['Embarked'].fillna(df['Embarked'].mode()[0])
+
+# STATE: df -> {"Cabin": N, "Fare": U, "Name": N, "Parch": U, "PassengerId": N, "PassengersInGroup": W, "SibSp": U, "Ticket": N, "Title": U, _: U}
+df['Fare'] = df['Fare'].fillna(df['Fare'].median())
+
+# STATE: df -> {"Cabin": N, "Name": N, "Parch": U, "PassengerId": N, "PassengersInGroup": W, "SibSp": U, "Ticket": N, "Title": U, _: U}
+df['Title'] = df['Title'].replace(['Lady', 'Countess','Capt', 'Col','Don', 'Dr', 'Major', 'Rev', 'Sir', 'Jonkheer', 'Dona'], 'Rare')
+
+# STATE: df -> {"Cabin": N, "Name": N, "Parch": U, "PassengerId": N, "PassengersInGroup": W, "SibSp": U, "Ticket": N, "Title": U, _: U}
+df['Title'] = df['Title'].replace('Mlle', 'Miss')
+
+# STATE: df -> {"Cabin": N, "Name": N, "Parch": U, "PassengerId": N, "PassengersInGroup": W, "SibSp": U, "Ticket": N, "Title": U, _: U}
+df['Title'] = df['Title'].replace('Ms', 'Miss')
+
+# STATE: df -> {"Cabin": N, "Name": N, "Parch": U, "PassengerId": N, "PassengersInGroup": W, "SibSp": U, "Ticket": N, "Title": U, _: U}
+df['Title'] = df['Title'].replace('Mme', 'Mrs')
+
+# STATE: df -> {"Cabin": N, "Name": N, "Parch": U, "PassengerId": N, "PassengersInGroup": W, "SibSp": U, "Ticket": N, _: U}
+df['PassengersInGroup'] = df['SibSp'] + df['Parch'] + 1
+
+# STATE: df -> {"Cabin": N, "Name": N, "Parch": N, "PassengerId": N, "SibSp": N, "Ticket": N, _: U}
+df.drop(['PassengerId', 'Name', 'Ticket', 'Cabin', 'SibSp', 'Parch'], axis=1, inplace=True)
+
+# STATE: df -> {_: U}
+df.head()
+
+# FINAL: df -> {_: N}
+


### PR DESCRIPTION
Added a columns usage static analyzer over pandas dataframes (based on pandas 1.1.5 semantics)

Supports:
- `read_csv` call to create a dataframe
- `drop`, `head`, `hist`, `tail`, `describe` and `info` call over a dataframe
- `min`, `max` and `median` aggregations
- `fillna` and `replace` operations

Future work:

- Add support for `concat` call
- Add support for creating non-dataframe variables (Now the analysis asumme that all variables are dataframes)
- Add support for if-else statements and loops
